### PR TITLE
80 create equal constraint

### DIFF
--- a/src/PanCAD/cad/freecad/sketch_constraints.py
+++ b/src/PanCAD/cad/freecad/sketch_constraints.py
@@ -10,7 +10,7 @@ from PanCAD.geometry.constraints.abstract_constraint import AbstractConstraint
 from PanCAD.geometry.constraints import (
     Coincident, Vertical, Horizontal,
     Distance, HorizontalDistance, VerticalDistance,
-    Radius, Diameter,
+    Radius, Diameter, Equal, Perpendicular, Parallel
 )
 from PanCAD.geometry.constants import ConstraintReference
 
@@ -77,6 +77,19 @@ def freecad_constraint_vertical(constraint: Vertical,
         return Sketcher.Constraint("Vertical", *args)
 
 @freecad_constraint.register
+def freecad_constraint_equal(constraint: Equal,
+                             args: tuple) -> Sketcher.Constraint:
+    return Sketcher.Constraint("Equal", *args[0::2])
+
+@freecad_constraint.register
+def freecad_constraint_perpendicular(constraint: Perpendicular,
+                                     args: tuple) -> Sketcher.Constraint:
+    return Sketcher.Constraint("Perpendicular", *args[0::2])
+
+@freecad_constraint.register
+def freecad_constraint_parallel(constraint: Parallel,
+                                args: tuple) -> Sketcher.Constraint:
+    return Sketcher.Constraint("Parallel", *args[0::2])
 
 # Utility Functions ############################################################
 def bug_fix_001_distance(sketch: Sketch, constraint: Distance) -> tuple[int]:

--- a/src/PanCAD/cad/freecad/sketch_constraints.py
+++ b/src/PanCAD/cad/freecad/sketch_constraints.py
@@ -1,0 +1,159 @@
+"""A module providing functions to generate FreeCAD sketch constraints"""
+
+from functools import singledispatch
+
+from PanCAD.cad.freecad import App, Sketcher
+from PanCAD.cad.freecad.constants import EdgeSubPart
+
+from PanCAD.geometry import Sketch, LineSegment
+from PanCAD.geometry.constraints.abstract_constraint import AbstractConstraint
+from PanCAD.geometry.constraints import (
+    Coincident, Vertical, Horizontal,
+    Distance, HorizontalDistance, VerticalDistance,
+    Radius, Diameter,
+)
+from PanCAD.geometry.constants import ConstraintReference
+
+# Primary Translation Function #################################################
+def translate_constraint(sketch: Sketch,
+                         constraint: AbstractConstraint):
+    if isinstance(constraint, Distance):
+        geometry_inputs = bug_fix_001_distance(sketch, constraint)
+    else:
+        geometry_inputs = get_constraint_inputs(sketch, constraint)
+    
+    return freecad_constraint(constraint, geometry_inputs)
+
+# Constraint Dispatch Functions ################################################
+@singledispatch
+def freecad_constraint(constraint: AbstractConstraint,
+                       args: tuple) -> Sketcher.Constraint:
+    """Returns a FreeCAD constraint that can be placed in a FreeCAD Sketch."""
+    raise NotImplementedError(f"Unsupported 1st type {constraint.__class__}")
+
+@freecad_constraint.register
+def freecad_constraint_coincident(constraint: Coincident,
+                                  args: tuple) -> Sketcher.Constraint:
+    return Sketcher.Constraint("Coincident", *args)
+
+@freecad_constraint.register
+def freecad_constraint_diameter(constraint: Diameter,
+                                args: tuple) -> Sketcher.Constraint:
+    geometry_index, _ = args
+    value_str = f"{constraint.value} {constraint.unit}"
+    return Sketcher.Constraint("Diameter", geometry_index,
+                               App.Units.Quantity(value_str))
+
+@freecad_constraint.register
+def freecad_constraint_distance(constraint: Distance,   
+                                args: tuple) -> Sketcher.Constraint:
+    value_str = f"{constraint.value} {constraint.unit}"
+    return Sketcher.Constraint("Distance", *args, App.Units.Quantity(value_str))
+
+@freecad_constraint.register
+def freecad_constraint_horizontal(constraint: Horizontal,
+                                  args: tuple) -> Sketcher.Constraint:
+    if len(constraint.get_constrained()) == 1:
+        geometry_index, _ = args
+        return Sketcher.Constraint("Horizontal", geometry_index)
+    else:
+        return Sketcher.Constraint("Horizontal", *args)
+
+@freecad_constraint.register
+def freecad_constraint_radius(constraint: Radius,
+                              args: tuple) -> Sketcher.Constraint:
+    geometry_index, _ = args
+    value_str = f"{constraint.value} {constraint.unit}"
+    return Sketcher.Constraint("Radius", geometry_index,
+                               App.Units.Quantity(value_str))
+
+@freecad_constraint.register
+def freecad_constraint_vertical(constraint: Vertical,
+                                args: tuple) -> Sketcher.Constraint:
+    if len(constraint.get_constrained()) == 1:
+        geometry_index, _ = args
+        return Sketcher.Constraint("Vertical", geometry_index)
+    else:
+        return Sketcher.Constraint("Vertical", *args)
+
+@freecad_constraint.register
+
+# Utility Functions ############################################################
+def bug_fix_001_distance(sketch: Sketch, constraint: Distance) -> tuple[int]:
+    """Returns a modified constraint input tuple that takes into account FreeCAD 
+    distance bugs.
+    
+    Known bugs
+    - Distance between two parallel lines is actually stored as a distance 
+    between the start point of the first line and the edge of the second 
+    line. This causes undefined behavior when the orientation constraint that 
+    made it possible to place the distance constraint is removed without 
+    removing the distance constraint. Additionally, this scenario takes fewer 
+    geometry inputs than normal (3 instead of 4).
+    
+    :param sketch: A PanCAD sketch.
+    :param constraint: A PanCAD Distance constraint.
+    :returns: A tuple of integer inputs to define a FreeCAD constraint.
+    """
+    original_inputs = zip(constraint.get_constrained(),
+                          constraint.get_references())
+    if all([isinstance(g, LineSegment) and r == ConstraintReference.CORE
+            for g, r in original_inputs]):
+        a_i, a_ref, b_i, b_ref = get_constraint_inputs(sketch, constraint)
+        return (a_i, EdgeSubPart.START, b_i)
+    else:
+        return get_constraint_inputs(sketch, constraint)
+
+def get_constraint_inputs(sketch: Sketch,
+                          constraint: AbstractConstraint) -> tuple[int]:
+    """Returns the indices required to reference constraint geometry in FreeCAD. 
+    FreeCAD references the sketch origin, x-axis, and y-axis with hidden 
+    external geometry elements. The origin is the start point of the x-axis 
+    line, the x-axis line is at index -1, and the y-axis line is at index 
+    -2. If those elements are referenced then they need to be mapped differently 
+    than they are in PanCAD and likely other programs.
+    
+    :param sketch: A PanCAD sketch.
+    :param constraint: A PanCAD Distance constraint.
+    :returns: A tuple of integer inputs to define a FreeCAD constraint.
+    """
+    original_inputs = zip(constraint.get_constrained(),
+                          constraint.get_references())
+    freecad_inputs = tuple()
+    for constrained, reference in original_inputs:
+        if constrained is sketch.get_sketch_coordinate_system():
+            # FreeCAD keeps its sketch coordinate system in negative index 
+            # locations, so this is a special case for constraints.
+            match reference:
+                case ConstraintReference.ORIGIN:
+                    index = -1
+                    subpart = EdgeSubPart.START
+                case ConstraintReference.X:
+                    index = -1
+                    subpart = EdgeSubPart.EDGE
+                case ConstraintReference.Y:
+                    index = -2
+                    subpart = EdgeSubPart.EDGE
+                case _:
+                    raise ValueError(f"Invalid ConstraintReference {reference}")
+        else:
+            index = sketch.get_index_of(constrained)
+            subpart = map_to_subpart(reference)
+        freecad_inputs = freecad_inputs + (index, subpart)
+    return freecad_inputs
+
+def map_to_subpart(pancad_reference: ConstraintReference) -> EdgeSubPart:
+    """Returns the EdgeSubPart that matches the PanCAD constraint reference.
+    
+    :param pancad_reference: A reference to a subpart of geometry.
+    :returns: The FreeCAD equivalent to the pancad_reference.
+    """
+    match pancad_reference:
+        case ConstraintReference.CORE:
+            return EdgeSubPart.EDGE
+        case ConstraintReference.START:
+            return EdgeSubPart.START
+        case ConstraintReference.END:
+            return EdgeSubPart.END
+        case ConstraintReference.CENTER:
+            return EdgeSubPart.CENTER

--- a/src/PanCAD/filetypes/part_file.py
+++ b/src/PanCAD/filetypes/part_file.py
@@ -41,7 +41,7 @@ class PartFile:
     
     def __init__(self,
                  filename: str,
-                 original_software: SoftwareName,
+                 original_software: SoftwareName=None,
                  features: tuple=None,
                  *,
                  metadata: dict=None,
@@ -66,7 +66,10 @@ class PartFile:
         else:
             self._coordinate_system = coordinate_system
         
-        self._initialize_metadata(metadata, original_software, metadata_map)
+        if original_software is None:
+            self._metadata = None
+        else:
+            self._initialize_metadata(metadata, original_software, metadata_map)
     
     # Public Methods
     def add_feature(self, feature: Sketch | Extrude):

--- a/src/PanCAD/geometry/constraints/__init__.py
+++ b/src/PanCAD/geometry/constraints/__init__.py
@@ -1,4 +1,6 @@
-from PanCAD.geometry.constraints.coincident import Coincident
+from PanCAD.geometry.constraints.state_constraint import (
+    Coincident, Equal, Parallel, Perpendicular, Tangent
+)
 from PanCAD.geometry.constraints.snapto import Horizontal, Vertical
 from PanCAD.geometry.constraints.distance import (
     HorizontalDistance, VerticalDistance, Distance, Radius, Diameter,

--- a/src/PanCAD/geometry/constraints/coincident.py
+++ b/src/PanCAD/geometry/constraints/coincident.py
@@ -1,28 +1,24 @@
-"""A module providing a constraint class for coincident relations between two 
-geometry elements.
-
+"""A module providing constraint classes for state constraints between strictly 
+two geometry elements. PanCAD defines state constraints to be constraints 
+between 2 elements that have a constant implied value or no value associated 
+with them. Perpendicular constraints that force lines to be angled 90 degrees to 
+each other and equal constraints that force lines to be the same length are 
+examples of state constraints.
 """
+
 from __future__ import annotations
 
+from abc import abstractmethod
 from functools import reduce
+from typing import Type
 
 from PanCAD.geometry.constraints.abstract_constraint import AbstractConstraint
 from PanCAD.geometry import (
     Point, Line, LineSegment, Plane, CoordinateSystem, Circle
 )
 from PanCAD.geometry.constants import ConstraintReference
-from PanCAD.geometry.spatial_relations import coincident
 
-class Coincident(AbstractConstraint):
-    # Type Tuples for checking with isinstance()
-    CONSTRAINED_TYPES = (Point, Line, LineSegment,
-                         Plane, CoordinateSystem, Circle)
-    GEOMETRY_TYPES = (Point, Line, LineSegment, Plane, Circle)
-    
-    # Type Hints
-    ConstrainedType = reduce(lambda x, y: x | y, CONSTRAINED_TYPES)
-    GeometryType = reduce(lambda x, y: x | y, GEOMETRY_TYPES)
-    
+class AbstractStateConstraint(AbstractConstraint):
     def __init__(self,
                  constrain_a: ConstrainedType, reference_a: ConstraintReference,
                  constrain_b: ConstrainedType, reference_b: ConstraintReference,
@@ -38,8 +34,9 @@ class Coincident(AbstractConstraint):
             raise ValueError("Geometry a and b must have the same number"
                              " of dimensions")
         
-        self._validate_constrained()
+        self._validate_parent_geometry()
         self._validate_geometry()
+        self._validate_combination()
     
     # Public Methods
     def get_constrained(self) -> tuple[ConstrainedType]:
@@ -58,22 +55,9 @@ class Coincident(AbstractConstraint):
         return (self._a_reference, self._b_reference)
     
     # Private Methods #
-    def _validate_constrained(self):
-        """Raises an error if the geometries are not one of the allowed 
-        types"""
-        if not any([isinstance(g, self.CONSTRAINED_TYPES)
-                    for g in self.get_geometry()]):
-            raise ValueError(
-                f"geometry a and b must be one of:\n{self.CONSTRAINED_TYPES}\n"
-                f"Given: {self._a.__class__} and {self._b.__class__}"
-            )
-        elif self._a is self._b:
-            raise ValueError("Constrained a/b cannot be the same geometry"
-                             " element")
-    
     def _validate_geometry(self):
-        """Raises an error if the constrainted geometries are not one of the 
-        allowed types"""
+        """Raises an error if the geometries are not one of the allowed types.
+        """
         if not any([isinstance(g, self.GEOMETRY_TYPES)
                     for g in self.get_geometry()]):
             classes = [g.__class__ for g in self.get_geometry()]
@@ -81,28 +65,150 @@ class Coincident(AbstractConstraint):
                 f"geometry a and b must be one of:\n{self.GEOMETRY_TYPES}\n"
                 f"Given: {classes}"
             )
+        elif self._a is self._b:
+            raise ValueError("Constrained a/b cannot be the same element")
+    
+    def _validate_parent_geometry(self):
+        """Raises an error if the parents (Ex: the line of the start point) of 
+        the geometries are not one of the allowed types. Also called constrained 
+        geometry.
+        """
+        if not any([isinstance(g, self.CONSTRAINED_TYPES)
+                    for g in self.get_constrained()]):
+            classes = [g.__class__ for g in self.get_constrained()]
+            raise ValueError(
+                f"geometry a and b must be one of:\n{self.CONSTRAINED_TYPES}\n"
+                f"Given: {classes}"
+            )
+    
+    # Abstract Shared Static Private Methods
+    def _is_combination(
+                self, 
+                one_parent_type: Type, one_reference_geometry: Type,
+                other_parent_type: Type, other_reference_geometry: Type,
+            ) -> bool:
+        """Returns whether the combination of parents and references in the 
+        constraint matches the given combination of types. The order of the 
+        parents does not matter.
+        
+        :param one_parent_type: One of the parent types.
+        :param one_reference_geometry: The reference geometry type of the parent 
+            found with the first type.
+        :param other_parent_type: The other parent type.
+        :param other_reference_geometry: The reference geometry type of the parent 
+            found with the second type.
+        :returns: Whether the relation matches the combination.
+        """
+        constrained = list(self.get_constrained())
+        references = list(self.get_references())
+        geometry = list(self.get_geometry())
+        
+        # Check parent types and 
+        if isinstance(self._a, one_parent_type):
+            one_parent, other_parent = constrained
+            one_reference, other_reference = references
+        elif isinstance(self._b, one_parent_type):
+            other_parent, one_parent = constrained
+            other_reference, one_reference = references
+        else:
+            return False
+        
+        if isinstance(one_parent.get_reference(one_reference),
+                      one_reference_geometry):
+            if isinstance(other_parent, other_parent_type):
+                return isinstance(other_parent.get_reference(other_reference),
+                                  other_reference_geometry)
+            else:
+                return False
+        else:
+            return False
+    
+    # Abstract Shared Private Methods #
+    
+    @abstractmethod
+    def _validate_combination(self):
+        """Raises an error if the geometry combination cannot be constrained."""
     
     # Python Dunders #
-    def __eq__(self, other: Coincident) -> bool:
-        """Checks whether two coincident relations are functionally the same by 
+    def __eq__(self, other: AbstractStateConstraint) -> bool:
+        """Checks whether two state constraints are functionally the same by 
         comparing the memory ids of their geometries.
         
-        :param other: Another coincident relationship.
+        :param other: Another constraint of the same type.
         :returns: Whether the relations are the same.
         """
         geometry_zip = zip(self.get_geometry(), other.get_geometry())
-        if isinstance(other, Coincident):
+        if isinstance(other, self.__class__):
             return all([g is other_g for g, other_g in geometry_zip])
         else:
             return NotImplemented
     
     def __repr__(self) -> str:
-        """Returns the short string representation of the Coincident"""
-        return f"<Coincident'{self.uid}'{repr(self._a)}{repr(self._b)}>"
+        """Returns the short string representation of the state constraint."""
+        return (f"<{self.__class__.__name__}'{self.uid}'"
+                f"{repr(self._a)}{repr(self._b)}>")
     
     def __str__(self) -> str:
-        """Returns the longer string representation of the Coincident"""
-        return (
-            f"PanCAD Coincident Constraint '{self.uid}' with {repr(self._a)}"
-            f" as geometry a and {repr(self._b)} as geometry b"
-        )
+        """Returns the longer string representation of the state constraint."""
+        return (f"PanCAD {self.__class__.__name__} Constraint '{self.uid}'"
+                f" with {repr(self._a)} as geometry a and {repr(self._b)}"
+                " as geometry b")
+
+class Coincident(AbstractStateConstraint):
+    """A constraint that forces two geometry elements to occupy the same 
+    location.
+    """
+    # Type Tuples for checking with isinstance()
+    CONSTRAINED_TYPES = (Circle, CoordinateSystem, Line, LineSegment,
+                         Plane, Point)
+    GEOMETRY_TYPES = (Circle, Line, LineSegment, Plane, Point)
+    # Type Hints
+    ConstrainedType = reduce(lambda x, y: x | y, CONSTRAINED_TYPES)
+    GeometryType = reduce(lambda x, y: x | y, GEOMETRY_TYPES)
+    
+    def _validate_combination(self):
+        if self._is_combination(LineSegment, LineSegment, Circle, Circle):
+            raise TypeError("Line segment edges cannot be made coincident with"
+                            " circle edges.")
+        elif self._is_combination(Line, Line, Circle, Circle):
+            raise TypeError("Line edges cannot be made coincident with"
+                            " circle edges.")
+
+class Equal(AbstractStateConstraint):
+    """A constraint that forces two geometry elements to have the same 
+    context-specific value. Ex: Two lines have the same length or two circles 
+    have the same radius.
+    """
+    CONSTRAINED_TYPES = (LineSegment, Circle)
+    GEOMETRY_TYPES = (LineSegment, Circle)
+    ConstrainedType = reduce(lambda x, y: x | y, CONSTRAINED_TYPES)
+    GeometryType = reduce(lambda x, y: x | y, GEOMETRY_TYPES)
+    # TODO: Add validation at this level to check that the combination of types 
+    # is valid
+
+class Parallel(AbstractStateConstraint):
+    """A constraint that forces two geometry elements to be side by side and 
+    have the same distance continuously between them.
+    """
+    CONSTRAINED_TYPES = (Circle, CoordinateSystem, Line, LineSegment, Plane)
+    GEOMETRY_TYPES = (Circle, Line, LineSegment, Plane)
+    ConstrainedType = reduce(lambda x, y: x | y, CONSTRAINED_TYPES)
+    GeometryType = reduce(lambda x, y: x | y, GEOMETRY_TYPES)
+
+class Perpendicular(AbstractStateConstraint):
+    """A constraint that forces two geometry elements to be angled 90 degrees 
+    relative to each other.
+    """
+    CONSTRAINED_TYPES = (Circle, CoordinateSystem, Line, LineSegment, Plane)
+    GEOMETRY_TYPES = (Circle, Line, LineSegment, Plane)
+    ConstrainedType = reduce(lambda x, y: x | y, CONSTRAINED_TYPES)
+    GeometryType = reduce(lambda x, y: x | y, GEOMETRY_TYPES)
+
+class Tangent(AbstractStateConstraint):
+    """A constraint that forces a line to touch a curve at a point while not 
+    also crossing the curve at that point.
+    """
+    CONSTRAINED_TYPES = (Circle, CoordinateSystem, Line, LineSegment, Plane)
+    GEOMETRY_TYPES = (Circle, Line, LineSegment, Plane)
+    ConstrainedType = reduce(lambda x, y: x | y, CONSTRAINED_TYPES)
+    GeometryType = reduce(lambda x, y: x | y, GEOMETRY_TYPES)

--- a/src/PanCAD/geometry/constraints/distance.py
+++ b/src/PanCAD/geometry/constraints/distance.py
@@ -258,8 +258,10 @@ class Distance(Abstract2GeometryDistance):
             # Distance can apply to 3D contexts, but a and b must match
             raise ValueError("Geometry a and b must have the same number"
                              " of dimensions")
-        elif self._a is self._b:
-            raise ValueError("geometry a/b cannot be the same geometry element")
+        elif (self._a.get_reference(self._a_reference)
+              is self._b.get_reference(self._b_reference)):
+            raise ValueError("subgeometry of a/b cannot be the same geometry"
+                             " element")
 
 # 2D Only Classes #
 ################################################################################

--- a/tests/test_filetypes/test_part_file.py
+++ b/tests/test_filetypes/test_part_file.py
@@ -161,8 +161,8 @@ class TestWritePartFileToFreeCAD(TestPartFile):
         )
         self.dump_folder = os.path.join(tests_folder, "test_output_dump")
     
-    def tearDown(self):
-        os.remove(self.filepath)
+    # def tearDown(self):
+        # os.remove(self.filepath)
     
     def test_to_freecad_create_body(self):
         # Name the file after the function its in

--- a/tests/test_geometry/test_coincident.py
+++ b/tests/test_geometry/test_coincident.py
@@ -33,7 +33,7 @@ class TestValidation(unittest.TestCase):
             c = Coincident(a, ConstraintReference.CORE,
                            b, ConstraintReference.CORE)
     
-    def test_combination_validation_line_circle_edges_reverse(self):
+    def test_combination_validation_line_circle_edges_reversec(self):
         a = LineSegment((0, 0), (1, 1))
         b = Circle((0, 0), 1)
         with self.assertRaises(TypeError):

--- a/tests/test_geometry/test_coincident.py
+++ b/tests/test_geometry/test_coincident.py
@@ -1,8 +1,8 @@
 import unittest
 
-from PanCAD.geometry import Point
+from PanCAD.geometry import Point, LineSegment, Circle
 from PanCAD.geometry.constraints import Coincident
-from PanCAD.geometry.constants import ConstraintReference as CR
+from PanCAD.geometry.constants import ConstraintReference
 
 class TestInit(unittest.TestCase):
     
@@ -13,15 +13,33 @@ class TestInit(unittest.TestCase):
     
     def test_point_init(self):
         # Checking whether init errors out nominally
-        c = Coincident(self.a, CR.CORE, self.b, CR.CORE, self.uid)
+        c = Coincident(self.a, ConstraintReference.CORE,
+                       self.b, ConstraintReference.CORE, self.uid)
     
     def test_point_change(self):
         # Check whether updating the point updates the value in coincident
-        c = Coincident(self.a, CR.CORE, self.b, CR.CORE, self.uid)
+        c = Coincident(self.a, ConstraintReference.CORE,
+                       self.b, ConstraintReference.CORE, self.uid)
         original_a = self.a.copy()
         new_a = Point(1, 1)
         self.a.update(new_a)
         self.assertEqual(c.get_constrained()[0], new_a)
+
+class TestValidation(unittest.TestCase):
+    def test_combination_validation_line_circle_edges(self):
+        a = LineSegment((0, 0), (1, 1))
+        b = Circle((0, 0), 1)
+        with self.assertRaises(TypeError):
+            c = Coincident(a, ConstraintReference.CORE,
+                           b, ConstraintReference.CORE)
+    
+    def test_combination_validation_line_circle_edges_reverse(self):
+        a = LineSegment((0, 0), (1, 1))
+        b = Circle((0, 0), 1)
+        with self.assertRaises(TypeError):
+            c = Coincident(b, ConstraintReference.CORE,
+                           a, ConstraintReference.CORE)
+    
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Closes #80 and #78. Also fixed a bug with distance that made it impossible to set the length of lines from start to end point. Moved the freecad constraint generation to its own file and reimplemented them as singledispatch functions. Renamed coincident file to state constraints since it's the same architecture as parallel, perpendicular, and equal.