### PR TITLE
pytest works by forcing python v3.11.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,11 @@ path = "src/pancad/__about__.py"
 [tool.hatch.envs.default]
 python = "3.11"
 
+[[tool.hatch.envs.hatch-test.matrix]]
+python = ["3.11"]
+
 [tool.hatch.envs.docs]
+python = "3.11"
 dependencies = [
     "alabaster==1.0.0",
     "babel==2.16.0",

--- a/tests/test_svg/test_path.py
+++ b/tests/test_svg/test_path.py
@@ -41,7 +41,7 @@ class TestGeometrySetting(unittest.TestCase):
             LineSegment((5, 5), (10, 10)),
         ]
         path = Path.from_geometry(self.path_id, geo_list)
-        self.assertEqual(path.d, "M 1,1 2,2 5,5 10,10")
+        self.assertEqual(path.d, "M1,1 2,2 5,5 10,10")
     
     def test_set_geometry_line_segments_unequal_points(self):
         geo_list = [
@@ -49,7 +49,7 @@ class TestGeometrySetting(unittest.TestCase):
             LineSegment((3, 3), (5, 5)),
         ]
         path = Path.from_geometry(self.path_id, geo_list)
-        self.assertEqual(path.d, "M 1,1 2,2 M 3,3 5,5")
+        self.assertEqual(path.d, "M1,1 2,2 M3,3 5,5")
     
     def test_geometry_uids(self):
         geo_list = []


### PR DESCRIPTION
Two svg tests were found to be silently failing due to a space difference, unsure why that was not appearing before. Closes #144 