### PR TITLE
docs: improve README link formatting and consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,33 +10,34 @@ from one file type to another.
 
 ## How to get it
 
-The source code is hosted on GitHub at: https://github.com/spky/pancad
+The source code is hosted on [GitHub][2].
 
-Binary installers for the latest release version are available at the
-[Python Package Index (PyPI)][2]
+Binary installers for the latest release version are available on the
+[Python Package Index (PyPI)][3]
+
+Install using pip:
 
 ```sh
-# PyPI
 pip install pancad
 ```
 
 ## License
 
 2025. This work has been marked as dedicated to the public domain.
-See [CC0-1.0][3]
+See [CC0-1.0][4]
 
 ## Dependencies
 
-- [NumPy][4] - Used for matrix multiplication and mathematical functions for 
-those arrays.
-- [quaternion][5] - Used for pesky quaternion defined coordinate systems.
-- [SciPy][6] - Used by quaternion.
+- [NumPy][5] - Used for matrix operations and numerical functions.
+- [quaternion][6] - Used for pesky quaternion defined coordinate systems.
+- [SciPy][7] - Used by quaternion.
 
 <!-- References -->
 
 [1]: https://pandoc.org/
-[2]: https://pypi.org/
-[3]: https://creativecommons.org/publicdomain/zero/1.0/
-[4]: https://numpy.org/
-[5]: https://quaternion.readthedocs.io/en/latest/
-[6]: https://scipy.org/
+[2]: https://github.com/spky/pancad
+[3]: https://pypi.org/project/pancad/
+[4]: https://creativecommons.org/publicdomain/zero/1.0/
+[5]: https://numpy.org/
+[6]: https://quaternion.readthedocs.io/en/latest/
+[7]: https://scipy.org/


### PR DESCRIPTION
This PR improves README formatting and link consistency.

Changes include:
- Converting the GitHub source link to reference-style format
- Minor wording improvement for the PyPI section
- Clearer installation instructions

No functional changes.