### PR TITLE
add doc links

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -10,6 +10,14 @@ project = 'pancad'
 copyright = '2024, spky'
 author = 'spky'
 
+# -- GitHub links for docs --------------------------------------------------
+html_context = {
+    'display_github': True,
+    'github_user': 'spky',
+    'github_repo': 'pancad',
+    'github_version': 'main/docs/source/',
+}
+
 import pancad.constants
 import pancad.geometry
 import pancad.constants

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
 ]
 [project.urls]
 Homepage = "https://github.com/spky/pancad"
+Documentation = "https://pancad.readthedocs.io/"
 Issues = "https://github.com/spky/pancad/issues"
 
 [tool.hatch.version]


### PR DESCRIPTION
hey, saw the issue about adding doc links to pypi and adding github links back from docs. 

added the docs url to project.urls in pyproject.toml and set up html_context in the sphinx config so there's a link back to the repo from the docs site.

let me know if you need anything else!