### PR TITLE
fix: remove unused partial import from spatial_relations.py

### DIFF
--- a/src/pancad/geometry/spatial_relations.py
+++ b/src/pancad/geometry/spatial_relations.py
@@ -5,7 +5,7 @@ constraints in CAD programs.
 
 Example Relations: Coincident, Parallel, Perpendicular, Skew
 """
-from functools import singledispatch, partial
+from functools import singledispatch
 import math
 
 import numpy as np


### PR DESCRIPTION
### What was wrong

The module `spatial_relations.py` imported `partial` from `functools`, but it was not used anywhere in the file.
This causes an unused import warning during linting.

### What I changed

Removed the unused `partial` import and kept only the required import:

```python
from functools import singledispatch
```

### Why this change

Removing unused imports improves code readability and keeps the codebase clean. It also prevents lint warnings.

### How to verify

1. Run the project tests using:

   ```
   python -m pytest
   ```
2. Ensure there are no lint warnings related to unused imports.
