### PR TITLE
195 7 args pylint

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,15 @@
+[MAIN]
+
+# Add files or directories matching the regular expressions patterns to the
+# ignore-list. The regex matches against paths and can be in Posix or Windows
+# format. Because '\\' represents the directory delimiter on Windows systems,
+# it can't be used as an escape character.
+ignore-paths=docs,dist,tests
+
+[DESIGN]
+
+# Maximum number of arguments for function / method.
+max-args=7
+
+# Maximum number of positional arguments for function / method.
+max-positional-arguments=7


### PR DESCRIPTION
Added a .pylintrc file to configure pylint to use 7 args (upped from 6 to eliminate all existing catches from stuff like ellipse). Also made it ignore docs, dist, and tests.