### PR TITLE
211 axis constraints

### DIFF
--- a/src/pancad/abstract.py
+++ b/src/pancad/abstract.py
@@ -235,6 +235,11 @@ class AbstractGeometrySystem(AbstractGeometry):
         the system.
         """
 
+    @property
+    @abstractmethod
+    def constraints(self) -> Sequence[AbstractConstraint]:
+        """The constraints on the elements inside the system's context."""
+
 class AbstractConstraint(PancadThing):
     """A class defining the interfaces provided by all pancad Constraint
     Elements.

--- a/src/pancad/constants/__init__.py
+++ b/src/pancad/constants/__init__.py
@@ -6,3 +6,4 @@ from ._software_name import SoftwareName
 from .constraint_reference import ConstraintReference
 from .feature_type import FeatureType
 from .sketch_constraint import SketchConstraint
+from ._solver_constants import ConstraintVariableName, ConstraintEquationName

--- a/src/pancad/constants/_solver_constants.py
+++ b/src/pancad/constants/_solver_constants.py
@@ -1,0 +1,35 @@
+"""A module providing constants for use in solving constraints."""
+
+from enum import StrEnum, auto
+
+class ConstraintVariableName(StrEnum):
+    """An enumeration of constraint function variable names."""
+
+    DIRECTION = auto()
+    """The unit direction vector of a Line or Axis."""
+    LOCATION = auto()
+    """The location vector of a Point."""
+    NORMAL = auto()
+    """The normal vector of a Plane."""
+    REF_POINT = auto()
+    """The reference point (closest point to the origin) location vector of a Line or Axis."""
+    PARAMETER = auto()
+    """An arbitrary parameter to represent the parameter of function that must
+    be met. For example: A point must exist on a line for it to be coincident,
+    but the solver may not care about the exact end result of the location
+    parameter, just that it can be solved.
+    """
+
+class ConstraintEquationName(StrEnum):
+    """An enumeration of constraint equation function names."""
+
+    POINT_POINT_COINCIDENT = auto()
+    """Point to Point coincident."""
+    POINT_LINE_COINCIDENT = auto()
+    """Point to Axis or Axis to Point coincident."""
+    LINE_REF_POINT = auto()
+    """Axis/Line Reference Point position vector must be perpendicular to the
+    Axis/Line direction to be the point closest to the origin.
+    """
+    UNIT_VECTOR = auto()
+    """This vector must be a unit vector."""

--- a/src/pancad/constants/_solver_constants.py
+++ b/src/pancad/constants/_solver_constants.py
@@ -27,6 +27,8 @@ class ConstraintEquationName(StrEnum):
     """Point to Point coincident."""
     POINT_LINE_COINCIDENT = auto()
     """Point to Axis or Axis to Point coincident."""
+    FIXED_POINT = auto()
+    """A point that must be placed at a constant location."""
     LINE_REF_POINT = auto()
     """Axis/Line Reference Point position vector must be perpendicular to the
     Axis/Line direction to be the point closest to the origin.

--- a/src/pancad/constants/sketch_constraint.py
+++ b/src/pancad/constants/sketch_constraint.py
@@ -43,6 +43,11 @@ class SketchConstraint(StrEnum):
     """Refers to constraints holding contextual values of two geometry elements
     to the same value. Example: 2 line segments to the same length.
     """
+    FIXED = auto()
+    """Refers to constraints that lock a geometry into its position, orientation,
+    and size. Example: A point can be fixed to its current location and an Axis
+    can be fixed to its current location and current direction.
+    """
     HORIZONTAL = auto()
     """Refers to constraints holding a single geometry element (or multiple
     geometry elements relative to each) other parallel to a 2D coordinate

--- a/src/pancad/constants/sketch_constraint.py
+++ b/src/pancad/constants/sketch_constraint.py
@@ -1,4 +1,4 @@
-"""A module providing an enumeration for the constraint types available to 2D 
+"""A module providing an enumeration for the constraint types available to 2D
 sketches"""
 
 from enum import StrEnum, auto
@@ -6,7 +6,12 @@ from enum import StrEnum, auto
 class SketchConstraint(StrEnum):
     """An enumeration used to refer to a type of sketch constraint."""
     ALIGN_AXES = auto()
-    """Refers to constraints aligning all axes between two coordinate systems.
+    """Refers to constraints aligning all axes between two coordinate systems or
+    aligning the axis directions of two Axis elements.
+    """
+    ANTI_ALIGN_AXES = auto()
+    """Refers to constraints to force two Axis elements to share anti-parallel
+    axis directions.
     """
     ANGLE = auto()
     """Refers to constraints on the angle between two geometry elements."""
@@ -16,15 +21,15 @@ class SketchConstraint(StrEnum):
     COLLINEAR = auto()
     """Refers to constraints holding geometry elements to the same line."""
     DISTANCE = auto()
-    """Refers to constraints holding geometry elements to a set distance from 
+    """Refers to constraints holding geometry elements to a set distance from
     each other at an arbitrary orientation.
     """
     DISTANCE_HORIZONTAL = auto()
-    """Refers to constraints holding geometry elements to a set horizontal 
+    """Refers to constraints holding geometry elements to a set horizontal
     distance from each other.
     """
     DISTANCE_VERTICAL = auto()
-    """Refers to constraints holding geometry elements to a set vertical 
+    """Refers to constraints holding geometry elements to a set vertical
     distance from each other.
     """
     DISTANCE_RADIUS = auto()
@@ -35,32 +40,32 @@ class SketchConstraint(StrEnum):
     value.
     """
     EQUAL = auto()
-    """Refers to constraints holding contextual values of two geometry elements 
+    """Refers to constraints holding contextual values of two geometry elements
     to the same value. Example: 2 line segments to the same length.
     """
     HORIZONTAL = auto()
-    """Refers to constraints holding a single geometry element (or multiple 
-    geometry elements relative to each) other parallel to a 2D coordinate 
+    """Refers to constraints holding a single geometry element (or multiple
+    geometry elements relative to each) other parallel to a 2D coordinate
     system's x axis.
     """
     PARALLEL = auto()
-    """Refers to constraints holding two geometry elements to be side by side 
+    """Refers to constraints holding two geometry elements to be side by side
     and have the same distance continuously between them.
     """
     PERPENDICULAR = auto()
-    """Refers to constraints holding two geometry elements to be angled 90 
+    """Refers to constraints holding two geometry elements to be angled 90
     degrees relative to each other.
     """
     SYMMETRIC = auto()
-    """Refers to constraints holding two geometry elements to the same position 
+    """Refers to constraints holding two geometry elements to the same position
     and orientation on opposite sides of a third geometry element.
     """
     TANGENT = auto()
-    """Refers to constraints holding a geometry element to touch a curve at a 
+    """Refers to constraints holding a geometry element to touch a curve at a
     point while not also crossing the curve at that point.
     """
     VERTICAL = auto()
-    """Refers to constraints holding a single geometry element (or multiple 
-    geometry elements relative to each other) parallel to a 2D coordinate 
+    """Refers to constraints holding a single geometry element (or multiple
+    geometry elements relative to each other) parallel to a 2D coordinate
     system's y axis.
     """

--- a/src/pancad/constraints/_generator.py
+++ b/src/pancad/constraints/_generator.py
@@ -11,7 +11,7 @@ from pancad.constraints.distance import (
 )
 from pancad.constraints.snapto import Horizontal, Vertical, Fixed
 from pancad.constraints.state_constraint import (
-    Coincident, Equal, Parallel, Perpendicular, AlignAxes
+    Coincident, Equal, Parallel, Perpendicular, AlignAxes, AntiAlignAxes
 )
 
 if TYPE_CHECKING:
@@ -26,6 +26,7 @@ if TYPE_CHECKING:
 
 SKETCH_CONSTRAINT_TO_CLASS = {
     SketchConstraint.ALIGN_AXES: AlignAxes,
+    SketchConstraint.ANTI_ALIGN_AXES: AntiAlignAxes,
     SketchConstraint.ANGLE: Angle,
     SketchConstraint.COINCIDENT: Coincident,
     SketchConstraint.HORIZONTAL: Horizontal,

--- a/src/pancad/constraints/_generator.py
+++ b/src/pancad/constraints/_generator.py
@@ -9,7 +9,7 @@ from pancad.constants import SketchConstraint
 from pancad.constraints.distance import (
     Angle, Diameter, Distance, HorizontalDistance, Radius, VerticalDistance
 )
-from pancad.constraints.snapto import Horizontal, Vertical
+from pancad.constraints.snapto import Horizontal, Vertical, Fixed
 from pancad.constraints.state_constraint import (
     Coincident, Equal, Parallel, Perpendicular, AlignAxes
 )
@@ -35,6 +35,7 @@ SKETCH_CONSTRAINT_TO_CLASS = {
     SketchConstraint.DISTANCE_HORIZONTAL: HorizontalDistance,
     SketchConstraint.DISTANCE_VERTICAL: VerticalDistance,
     SketchConstraint.EQUAL: Equal,
+    SketchConstraint.FIXED: Fixed,
     SketchConstraint.PARALLEL: Parallel,
     SketchConstraint.PERPENDICULAR: Perpendicular,
     SketchConstraint.VERTICAL: Vertical,
@@ -43,7 +44,7 @@ SKETCH_CONSTRAINT_TO_CLASS = {
 @overload
 def make_constraint(type_: SketchConstraint, *geometry: AbstractGeometry,
                     uid: UUID | str=None
-                    ) -> AbstractStateConstraint | AbstractSnapTo: ...
+                    ) -> AbstractStateConstraint | AbstractSnapTo | Fixed: ...
 
 @overload
 def make_constraint(type_: SketchConstraint, *geometry: AbstractGeometry,

--- a/src/pancad/constraints/snapto.py
+++ b/src/pancad/constraints/snapto.py
@@ -15,6 +15,21 @@ if TYPE_CHECKING:
     from pancad.abstract import AbstractGeometry, AbstractGeometrySystem
     from pancad.constants import ConstraintReference
 
+class Fixed(AbstractConstraint):
+    """A class of constraint that can be applied to a single element of geometry
+    to lock down its location, orientation, and any size parameters.
+    """
+
+    type_name = SketchConstraint.FIXED
+
+    def __init__(self, *geometry: AbstractGeometry,
+                 uid: str=None, system: AbstractGeometrySystem=None) -> None:
+        self.uid = uid
+        super().__init__(system)
+        if len(geometry) != 1:
+            raise ValueError(f"Expected 1 geometry, got: {geometry}")
+        self._geometry = geometry
+
 class AbstractSnapTo(AbstractConstraint):
     """An abstract class of constraints that can be applied to a set of **one 
     or two** geometries without any further definition.

--- a/src/pancad/constraints/state_constraint.py
+++ b/src/pancad/constraints/state_constraint.py
@@ -68,7 +68,14 @@ class Tangent(AbstractStateConstraint):
 
 class AlignAxes(AbstractStateConstraint):
     """A constraint that forces two coordinate systems to share the same
-    location and the same respective axis directions.
+    location and the same respective axis directions or two axes to share the
+    same axis directons.
     """
 
     type_name = SketchConstraint.ALIGN_AXES
+
+class AntiAlignAxes(AbstractStateConstraint):
+    """A constraint that forces two axes to share anti-parallel axis directions.
+    """
+
+    type_name = SketchConstraint.ANTI_ALIGN_AXES

--- a/src/pancad/constraints/state_constraint.py
+++ b/src/pancad/constraints/state_constraint.py
@@ -69,13 +69,14 @@ class Tangent(AbstractStateConstraint):
 class AlignAxes(AbstractStateConstraint):
     """A constraint that forces two coordinate systems to share the same
     location and the same respective axis directions or two axes to share the
-    same axis directons.
+    same axis directons. When used on two axes their locations may be different.
     """
 
     type_name = SketchConstraint.ALIGN_AXES
 
 class AntiAlignAxes(AbstractStateConstraint):
-    """A constraint that forces two axes to share anti-parallel axis directions.
+    """A constraint that forces two axes to share anti-parallel axis directions. 
+    The two axes' locations may be different.
     """
 
     type_name = SketchConstraint.ANTI_ALIGN_AXES

--- a/src/pancad/utils/solvers.py
+++ b/src/pancad/utils/solvers.py
@@ -193,6 +193,7 @@ class ConstraintVariable:
     initial: Real | SpaceVector
     start: int
     delim: str = dataclasses.field(repr=False)
+    element: AbstractGeometry | AbstractConstraint
 
     @property
     def key(self) -> str:
@@ -209,8 +210,8 @@ class ConstraintVariable:
 
 @dataclasses.dataclass
 class ConstraintEquation:
-    """A dataclass for tracking imposed and internal constraint function names
-    and parameter names.
+    """A dataclass for tracking imposed and internal constraint equation function
+    names and parameter names.
     """
     source: str
     name: CEN
@@ -260,25 +261,39 @@ class SystemSolver:
     def solve(self, method: str="lm", **kwargs) -> npt.NDArray:
         """Returns the roots of the system's functions as a 1D numpy array.
 
-        :param method: The type of solver that should be used. Defaults to 
+        :param method: The type of solver that should be used. Defaults to
             Levenberg-Marquardt (lm). See scipy.optimize.root for other options.
         """
         return find_root(self.fun, self._x0, method=method, **kwargs)
 
     def label_x(self, x: npt.NDArray) -> str:
         """Returns a string table with each vector variable value labeled and indexed."""
-        column_map = {"#": "#", "Value": "value", "Name": "name", "Source": "source"}
+        column_map = {
+            "#": "#",
+            "Value": "value",
+            "Name": "name",
+            "Source": "source",
+            "Element": "element",
+        }
         data = []
         index = 0
         i = 0
         for var in self._variables:
             for i, value in enumerate(x[slice(*var.get_slicer())], index):
-                data.append({"#": i, "value": value, "name": var.name, "source": var.source})
+                data.append(
+                    {
+                        "#": i,
+                        "value": value,
+                        "name": var.name,
+                        "source": var.source,
+                        "element": var.element,
+                    }
+                )
             index = i + 1
         return get_table_string(data, column_map)
 
     def label_fun(self, results: npt.NDArray) -> str:
-        """Returns a string table with each vector variable value labeled and 
+        """Returns a string table with each vector variable value labeled and
         indexed assuming the vector is in the same order as the equation function
         output.
         """
@@ -346,7 +361,8 @@ class SystemSolver:
             axis = next(g for g in constraint.get_geometry() if isinstance(g, Axis))
             point = next(g for g in constraint.get_geometry() if isinstance(g, Point))
             t_param = ConstraintVariable(constraint.uid, CVN.PARAMETER, 0,
-                                         len(self._x0), self._delim)
+                                         len(self._x0), self._delim,
+                                         constraint)
             self._variables.append(t_param)
             self._x0.append(t_param.initial)
             params = [
@@ -416,14 +432,14 @@ class SystemSolver:
         }
         for name, vector in values.items():
             variable = ConstraintVariable(geometry.uid, name, vector,
-                                          len(self._x0), self._delim)
+                                          len(self._x0), self._delim, geometry)
             self._x0.extend(variable.initial)
             self._variables.append(variable)
 
     @_add_geometry_variables.register
     def _point_vars(self, geometry: Point) -> None:
         variable = ConstraintVariable(geometry.uid, CVN.LOCATION, geometry.cartesian,
-                                      len(self._x0), self._delim)
+                                      len(self._x0), self._delim, geometry)
         self._x0.extend(variable.initial)
         self._variables.append(variable)
 

--- a/src/pancad/utils/solvers.py
+++ b/src/pancad/utils/solvers.py
@@ -4,18 +4,30 @@ they would be cyclically dependent.
 """
 from __future__ import annotations
 
+import dataclasses
 from typing import TYPE_CHECKING
-from functools import singledispatch
+from functools import singledispatch, singledispatchmethod
 
 import numpy as np
 
-from pancad.abstract import AbstractGeometry
+from pancad.abstract import AbstractGeometry, AbstractConstraint
+from pancad.constants import (ConstraintVariableName as CVN,
+                              ConstraintEquationName as CEN)
+
+from pancad.constraints.state_constraint import Coincident
 from pancad.geometry.line_segment import LineSegment
-from pancad.utils.pancad_types import FitBox2D
+from pancad.geometry.line import Axis
+from pancad.geometry.point import Point
+from pancad.utils.pancad_types import FitBox2D, SpaceVector
 
 if TYPE_CHECKING:
     from numbers import Real
     from typing import Literal
+    from uuid import UUID
+
+    import numpy.typing as npt
+
+    from pancad.abstract import AbstractGeometrySystem, PancadThing
 
 def get_length(segment: LineSegment,
                along: Literal["x", "y", "z"]=None) -> float:
@@ -124,3 +136,190 @@ def _line_segment(geometry: LineSegment) -> FitBox2D:
     max_coords = (max(geometry.start.x, geometry.end.x),
                   max(geometry.start.y, geometry.end.y))
     return FitBox2D(min_coords, max_coords)
+
+################################################################################
+# Constraint Residuals
+################################################################################
+
+@dataclasses.dataclass
+class ConstraintVariable:
+    """A dataclass for tracking the names of variables used by constraint functions.
+
+    :param source: The unique id of the source.
+    :param name: The ConstraintVariableName that defines what part of the source
+        element the variable is referring to.
+    :param initial: The initial value of the variable.
+    :param start: The start index for the variable.
+    """
+    source: str | UUID
+    name: CVN
+    initial: Real | SpaceVector
+    start: int
+    delim: str = dataclasses.field(repr=False)
+
+    @property
+    def key(self) -> str:
+        """The identifying unique key of the constraint variable."""
+        return self.delim.join(map(str, [self.source, self.name]))
+
+    def get_slicer(self) -> tuple[int, int]:
+        """Returns first variable index and last index + 1 of the variable vector
+        representing this value.
+        """
+        if isinstance(self.initial, tuple):
+            return (self.start, self.start + len(self.initial))
+        return (self.start, self.start + 1)
+
+@dataclasses.dataclass
+class ConstraintFunction:
+    """A dataclass for tracking imposed and internal constraint function names
+    and parameter names.
+    """
+    source: str
+    name: CEN
+    params: list[ConstraintVariable] = dataclasses.field(repr=False)
+    delim: str = dataclasses.field(repr=False)
+
+    @property
+    def key(self) -> str:
+        """The identifying unique key of the constraint function."""
+        return self.delim.join(map(str, [self.source, self.name]))
+
+def line_ref_point_res(direction: npt.NDArray, point: npt.NDArray) -> npt.NDArray:
+    """Returns the residual for how close an axis or line's reference point is to
+    being the closest to origin point.
+    """
+    return np.array([np.dot(direction, point)])
+
+def unit_vector_res(vector: npt.NDArray) -> npt.NDArray:
+    """Returns the residual for how close a vector is to being a unit vector."""
+    return np.array([np.sum(np.array(vector)**2) - 1])
+
+def point_line_coincident_res(direction: npt.NDArray, ref_point: np.NDArray,
+                              point: npt.NDArray, t_param: Real) -> npt.NDArray:
+    """Returns the residual for how close a point is to being coincident on an
+    axis or line.
+    """
+    return np.array(direction) * t_param + np.array(ref_point) - np.array(point)
+
+class SystemSolver:
+    """A class that solves a geometry system's internal and imposed constraints
+    and updates its geometry to meet them.
+    """
+    _delim = "_"
+    _func_map = {
+        CEN.UNIT_VECTOR: unit_vector_res,
+        CEN.LINE_REF_POINT: line_ref_point_res,
+        CEN.POINT_LINE_COINCIDENT: point_line_coincident_res,
+    }
+
+    def __init__(self, system: AbstractGeometrySystem) -> None:
+        self._system = system
+        self._functions = []
+        self._variables = []
+        self._x0 = []
+        for c in self._system.constraints:
+            self._add_constraint(c)
+
+    def fun(self, x: npt.NDArray) -> npt.NDArray:
+        """Returns the residuals of the system for a given vector value."""
+        results = []
+        for func in self._functions:
+            results.append(self._calc_func(func, x))
+        return np.concatenate(results)
+
+    def _calc_func(self, func: ConstraintFunction, x: npt.NDArray) -> Real:
+        params = [x[slice(*p.get_slicer())] for p in func.params]
+        return self._func_map[func.name](*params)
+
+    def _get_var(self, source: AbstractGeometry | AbstractConstraint, name: CVN
+                 ) -> ConstraintVariable:
+        source_vars = [v for v in self._variables if v.source == source.uid]
+        try:
+            return next(v for v in source_vars if v.name == name)
+        except StopIteration as exc:
+            msg = f"Could not find a {name} variable for {source}"
+            raise LookupError(msg) from exc
+
+    @singledispatchmethod
+    def _add_constraint(self, constraint: AbstractConstraint) -> None:
+        """Adds a constraint to the residuals list."""
+        msg = f"Solving the constraint type of {constraint} has not yet been implemented"
+        raise NotImplementedError(msg)
+
+    @_add_constraint.register
+    def _coincident(self, constraint: Coincident) -> None:
+        for geo in constraint.get_parents():
+            # Ensure the parent geometry constraints have been added.
+            if not any(v.source == geo.uid for v in self._variables):
+                self._add_geometry_variables(geo)
+                self._add_geometry_funcs(geo)
+        geo_types = {type(g) for g in constraint.get_geometry()}
+
+        # Add coincident constraint equation based on geometry combo.
+        if geo_types == {Axis, Point}:
+            # # Point and Axis
+            axis = next(g for g in constraint.get_geometry() if isinstance(g, Axis))
+            point = next(g for g in constraint.get_geometry() if isinstance(g, Point))
+            t_param = ConstraintVariable(constraint.uid, CVN.PARAMETER, 0,
+                                         len(self._x0), self._delim)
+            self._variables.append(t_param)
+            self._x0.append(t_param.initial)
+            params = [self._get_var(axis, CVN.DIRECTION),
+                      self._get_var(axis, CVN.REF_POINT),
+                      self._get_var(point, CVN.LOCATION),
+                      t_param]
+            func = ConstraintFunction(constraint.uid, CEN.POINT_LINE_COINCIDENT,
+                                      params, self._delim)
+            self._functions.append(func)
+        elif geo_types == {Point}:
+            # Both are points
+            raise NotImplementedError("Point to point not completed yet")
+        else:
+            msg = (f"Coincident combo {constraint.get_parents()} is not"
+                   " supported and/or may be invalid.")
+            raise NotImplementedError(msg)
+
+    @singledispatchmethod
+    def _add_geometry_funcs(self, geometry: AbstractGeometry) -> None:
+        """Adds a geometry's internal constraints to the function list."""
+        if not isinstance(geometry, Point):
+            msg = (f"Solving the internal geometry constraints of {geometry} has not"
+                   " yet been implemented")
+            raise NotImplementedError(msg)
+
+    @_add_geometry_funcs.register
+    def _axis(self, geometry: Axis) -> None:
+        geo_vars = [v for v in self._variables if v.source == geometry.uid]
+        func_param_map = {CEN.LINE_REF_POINT: [CVN.DIRECTION, CVN.REF_POINT],
+                          CEN.UNIT_VECTOR: [CVN.DIRECTION]}
+        for name, params in func_param_map.items():
+            func = ConstraintFunction(geometry.uid,
+                                      name,
+                                      [v for v in geo_vars if v.name in params],
+                                      self._delim)
+            self._functions.append(func)
+
+    @singledispatchmethod
+    def _add_geometry_variables(self, geometry: AbstractGeometry) -> None:
+        """Adds a geometry's internal variables to the variable list."""
+        msg = (f"Solving the internal geometry constraints of {geometry} has not"
+               " yet been implemented")
+        raise NotImplementedError(msg)
+
+    @_add_geometry_variables.register
+    def _axis_vars(self, geometry: Axis) -> None:
+        values = {CVN.DIRECTION: geometry.direction,
+                  CVN.REF_POINT: geometry.reference_point.cartesian}
+        for name, vector in values.items():
+            variable = ConstraintVariable(geometry.uid, name, vector,
+                                          len(self._x0), self._delim)
+            self._x0.extend(variable.initial)
+            self._variables.append(variable)
+
+    @_add_geometry_variables.register
+    def _point_vars(self, geometry: Point) -> None:
+        variable = ConstraintVariable(geometry.uid, CVN.LOCATION, geometry.cartesian,
+                                      len(self._x0), self._delim)
+        self._x0.extend(variable.initial)
+        self._variables.append(variable)

--- a/src/pancad/utils/solvers.py
+++ b/src/pancad/utils/solvers.py
@@ -6,19 +6,24 @@ from __future__ import annotations
 
 import dataclasses
 from typing import TYPE_CHECKING
+import textwrap
+from itertools import repeat
 from functools import singledispatch, singledispatchmethod
 
 import numpy as np
+from scipy.optimize import root as find_root
 
 from pancad.abstract import AbstractGeometry, AbstractConstraint
 from pancad.constants import (ConstraintVariableName as CVN,
                               ConstraintEquationName as CEN)
 
 from pancad.constraints.state_constraint import Coincident
+from pancad.constraints.snapto import Fixed
 from pancad.geometry.line_segment import LineSegment
 from pancad.geometry.line import Axis
 from pancad.geometry.point import Point
 from pancad.utils.pancad_types import FitBox2D, SpaceVector
+from pancad.utils.text_formatting import get_table_string
 
 if TYPE_CHECKING:
     from numbers import Real
@@ -141,6 +146,38 @@ def _line_segment(geometry: LineSegment) -> FitBox2D:
 # Constraint Residuals
 ################################################################################
 
+def line_ref_point_res(eq: ConstraintEquation, x: npt.NDArray) -> npt.NDArray:
+    """Returns the residual for how close an axis or line's reference point is to
+    being the closest to origin point.
+    """
+    point, direction = [x[slice(*p.get_slicer())] for p in eq.params]
+    return np.array([np.dot(direction, point)])
+
+def unit_vector_res(eq: ConstraintEquation, x: npt.NDArray) -> npt.NDArray:
+    """Returns the residual for how close a vector is to being a unit vector."""
+    vector = x[slice(*eq.params[0].get_slicer())]
+    return np.array([np.sum(np.array(vector)**2) - 1])
+
+def point_line_coincident_res(eq: ConstraintEquation, x: npt.NDArray) -> npt.NDArray:
+    """Returns the residual for how close a point is to being coincident on an
+    axis or line.
+    """
+    ref_point, direction, point, t_param = [x[slice(*p.get_slicer())] for p in eq.params]
+    t_param = t_param[0]
+    return np.array(direction) * t_param + np.array(ref_point) - np.array(point)
+
+def fixed_point_res(eq: ConstraintEquation, x: npt.NDArray) -> npt.NDArray:
+    """Returns the residual for how close a fixed point is to its required location."""
+    position_slice = slice(*eq.params[0].get_slicer())
+    return np.array(x[position_slice]) - np.array(eq.x0[position_slice])
+
+RESIDUAL_FUNCS = {
+    CEN.UNIT_VECTOR: unit_vector_res,
+    CEN.LINE_REF_POINT: line_ref_point_res,
+    CEN.POINT_LINE_COINCIDENT: point_line_coincident_res,
+    CEN.FIXED_POINT: fixed_point_res,
+}
+
 @dataclasses.dataclass
 class ConstraintVariable:
     """A dataclass for tracking the names of variables used by constraint functions.
@@ -171,7 +208,7 @@ class ConstraintVariable:
         return (self.start, self.start + 1)
 
 @dataclasses.dataclass
-class ConstraintFunction:
+class ConstraintEquation:
     """A dataclass for tracking imposed and internal constraint function names
     and parameter names.
     """
@@ -179,28 +216,16 @@ class ConstraintFunction:
     name: CEN
     params: list[ConstraintVariable] = dataclasses.field(repr=False)
     delim: str = dataclasses.field(repr=False)
+    x0: list[Real]
 
     @property
     def key(self) -> str:
         """The identifying unique key of the constraint function."""
         return self.delim.join(map(str, [self.source, self.name]))
 
-def line_ref_point_res(direction: npt.NDArray, point: npt.NDArray) -> npt.NDArray:
-    """Returns the residual for how close an axis or line's reference point is to
-    being the closest to origin point.
-    """
-    return np.array([np.dot(direction, point)])
-
-def unit_vector_res(vector: npt.NDArray) -> npt.NDArray:
-    """Returns the residual for how close a vector is to being a unit vector."""
-    return np.array([np.sum(np.array(vector)**2) - 1])
-
-def point_line_coincident_res(direction: npt.NDArray, ref_point: np.NDArray,
-                              point: npt.NDArray, t_param: Real) -> npt.NDArray:
-    """Returns the residual for how close a point is to being coincident on an
-    axis or line.
-    """
-    return np.array(direction) * t_param + np.array(ref_point) - np.array(point)
+    def calc(self, x: npt.NDArray) -> npt.NDArray:
+        """Calculates the equation's residual for a given vector value."""
+        return RESIDUAL_FUNCS[self.name](self, x)
 
 class SystemSolver:
     """A class that solves a geometry system's internal and imposed constraints
@@ -211,6 +236,7 @@ class SystemSolver:
         CEN.UNIT_VECTOR: unit_vector_res,
         CEN.LINE_REF_POINT: line_ref_point_res,
         CEN.POINT_LINE_COINCIDENT: point_line_coincident_res,
+        CEN.FIXED_POINT: fixed_point_res,
     }
 
     def __init__(self, system: AbstractGeometrySystem) -> None:
@@ -219,43 +245,101 @@ class SystemSolver:
         self._variables = []
         self._x0 = []
         for c in self._system.constraints:
+            for geo in c.get_parents():
+                # Make sure the geometry variables/constraints have been added
+                if not any(v.source == geo.uid for v in self._variables):
+                    self._add_geometry_variables(geo)
+                    self._add_geometry_funcs(geo)
             self._add_constraint(c)
 
     def fun(self, x: npt.NDArray) -> npt.NDArray:
         """Returns the residuals of the system for a given vector value."""
-        results = []
-        for func in self._functions:
-            results.append(self._calc_func(func, x))
-        return np.concatenate(results)
+        result = np.concatenate([f.calc(x) for f in self._functions])
+        return result
 
-    def _calc_func(self, func: ConstraintFunction, x: npt.NDArray) -> Real:
-        params = [x[slice(*p.get_slicer())] for p in func.params]
-        return self._func_map[func.name](*params)
+    def solve(self, method: str="lm", **kwargs) -> npt.NDArray:
+        """Returns the roots of the system's functions as a 1D numpy array.
+
+        :param method: The type of solver that should be used. Defaults to 
+            Levenberg-Marquardt (lm). See scipy.optimize.root for other options.
+        """
+        return find_root(self.fun, self._x0, method=method, **kwargs)
+
+    def label_x(self, x: npt.NDArray) -> str:
+        """Returns a string table with each vector variable value labeled and indexed."""
+        column_map = {"#": "#", "Value": "value", "Name": "name", "Source": "source"}
+        data = []
+        index = 0
+        i = 0
+        for var in self._variables:
+            for i, value in enumerate(x[slice(*var.get_slicer())], index):
+                data.append({"#": i, "value": value, "name": var.name, "source": var.source})
+            index = i + 1
+        return get_table_string(data, column_map)
+
+    def label_fun(self, results: npt.NDArray) -> str:
+        """Returns a string table with each vector variable value labeled and 
+        indexed assuming the vector is in the same order as the equation function
+        output.
+        """
+        column_map = {
+            "#": "#",
+            "Sub #": "sub",
+            "Value": "value",
+            "Name": "name",
+            "Source": "source"
+        }
+        data = []
+        start = 0
+        i = 0
+        for f in self._functions:
+            try:
+                end = start + len(f.calc(self._x0))
+            except TypeError:
+                end = start + 1
+            for i, value in enumerate(results[slice(start, end)], start):
+                data.append(
+                    {
+                        "#": i,
+                        "sub": i - start,
+                        "value": value,
+                        "name": f.name,
+                        "source": f.source,
+                    }
+                )
+            start = i + 1
+        return get_table_string(data, column_map)
 
     def _get_var(self, source: AbstractGeometry | AbstractConstraint, name: CVN
                  ) -> ConstraintVariable:
+        """Returns the ConstraintVariable for a given source and variable name.
+
+        :raises LookupError: When the source or variable could not be found.
+        """
         source_vars = [v for v in self._variables if v.source == source.uid]
         try:
             return next(v for v in source_vars if v.name == name)
         except StopIteration as exc:
+            if not source_vars:
+                msg = ("Could not find any variables for source"
+                       f" {source} while looking for {name}")
+                raise LookupError(msg) from exc
             msg = f"Could not find a {name} variable for {source}"
             raise LookupError(msg) from exc
 
     @singledispatchmethod
     def _add_constraint(self, constraint: AbstractConstraint) -> None:
-        """Adds a constraint to the residuals list."""
+        """Adds a constraint to the residuals list.
+
+        :raises NotImplementedError: When the constraint type or combination of
+            constrained geometry types is not supported.
+        """
         msg = f"Solving the constraint type of {constraint} has not yet been implemented"
         raise NotImplementedError(msg)
 
     @_add_constraint.register
     def _coincident(self, constraint: Coincident) -> None:
-        for geo in constraint.get_parents():
-            # Ensure the parent geometry constraints have been added.
-            if not any(v.source == geo.uid for v in self._variables):
-                self._add_geometry_variables(geo)
-                self._add_geometry_funcs(geo)
         geo_types = {type(g) for g in constraint.get_geometry()}
-
         # Add coincident constraint equation based on geometry combo.
         if geo_types == {Axis, Point}:
             # # Point and Axis
@@ -265,25 +349,39 @@ class SystemSolver:
                                          len(self._x0), self._delim)
             self._variables.append(t_param)
             self._x0.append(t_param.initial)
-            params = [self._get_var(axis, CVN.DIRECTION),
-                      self._get_var(axis, CVN.REF_POINT),
-                      self._get_var(point, CVN.LOCATION),
-                      t_param]
-            func = ConstraintFunction(constraint.uid, CEN.POINT_LINE_COINCIDENT,
-                                      params, self._delim)
-            self._functions.append(func)
+            params = [
+                self._get_var(axis, CVN.REF_POINT),
+                self._get_var(axis, CVN.DIRECTION),
+                self._get_var(point, CVN.LOCATION),
+                t_param,
+            ]
+            func = ConstraintEquation(constraint.uid, CEN.POINT_LINE_COINCIDENT,
+                                      params, self._delim, self._x0)
         elif geo_types == {Point}:
             # Both are points
             raise NotImplementedError("Point to point not completed yet")
         else:
             msg = (f"Coincident combo {constraint.get_parents()} is not"
-                   " supported and/or may be invalid.")
+                   " supported and/or may be invalid")
             raise NotImplementedError(msg)
+        self._functions.append(func)
+
+    @_add_constraint.register
+    def _fixed(self, constraint: Fixed) -> None:
+        geo = constraint.get_geometry()[0]
+        if isinstance(geo, Point):
+            params = [self._get_var(geo, CVN.LOCATION)]
+            func = ConstraintEquation(constraint.uid, CEN.FIXED_POINT,
+                                      params, self._delim, self._x0)
+        else:
+            msg = f"Fixed relation for {geo} is not supported and/or may be invalid"
+            raise NotImplementedError(msg)
+        self._functions.append(func)
 
     @singledispatchmethod
     def _add_geometry_funcs(self, geometry: AbstractGeometry) -> None:
         """Adds a geometry's internal constraints to the function list."""
-        if not isinstance(geometry, Point):
+        if not isinstance(geometry, Point): # Point has no internal constraints
             msg = (f"Solving the internal geometry constraints of {geometry} has not"
                    " yet been implemented")
             raise NotImplementedError(msg)
@@ -291,13 +389,16 @@ class SystemSolver:
     @_add_geometry_funcs.register
     def _axis(self, geometry: Axis) -> None:
         geo_vars = [v for v in self._variables if v.source == geometry.uid]
-        func_param_map = {CEN.LINE_REF_POINT: [CVN.DIRECTION, CVN.REF_POINT],
-                          CEN.UNIT_VECTOR: [CVN.DIRECTION]}
+        func_param_map = {
+            CEN.LINE_REF_POINT: [CVN.DIRECTION, CVN.REF_POINT],
+            CEN.UNIT_VECTOR: [CVN.DIRECTION]
+        }
         for name, params in func_param_map.items():
-            func = ConstraintFunction(geometry.uid,
+            func = ConstraintEquation(geometry.uid,
                                       name,
                                       [v for v in geo_vars if v.name in params],
-                                      self._delim)
+                                      self._delim,
+                                      self._x0)
             self._functions.append(func)
 
     @singledispatchmethod
@@ -309,8 +410,10 @@ class SystemSolver:
 
     @_add_geometry_variables.register
     def _axis_vars(self, geometry: Axis) -> None:
-        values = {CVN.DIRECTION: geometry.direction,
-                  CVN.REF_POINT: geometry.reference_point.cartesian}
+        values = {
+            CVN.REF_POINT: geometry.reference_point.cartesian,
+            CVN.DIRECTION: geometry.direction,
+        }
         for name, vector in values.items():
             variable = ConstraintVariable(geometry.uid, name, vector,
                                           len(self._x0), self._delim)
@@ -323,3 +426,43 @@ class SystemSolver:
                                       len(self._x0), self._delim)
         self._x0.extend(variable.initial)
         self._variables.append(variable)
+
+    @staticmethod
+    def _var_data(var: ConstraintVariable) -> dict[str, str | SpaceVector | Real]:
+        """Returns a dict of variable data from a ConstraintVariable for reporting."""
+        if isinstance(var.initial, tuple):
+            end = var.start + len(var.initial)
+        else:
+            end = var.start + 1
+        return {
+            "source": str(var.source),
+            "name": var.name,
+            "init": var.initial,
+            "i": (var.start, end - 1)
+        }
+
+    def __str__(self) -> str:
+        strings = []
+        var_column_map = {
+            "Source UID": "source",
+            "Name": "name",
+            "Initial Value": "init",
+            "Indices": "i",
+        }
+        variable_data = [self._var_data(v) for v in self._variables]
+        table = get_table_string(variable_data, var_column_map)
+        strings.append("Solver Variables".center(max(map(len, table.splitlines()))))
+        strings.append(table)
+        func_strings = []
+        for i, f in enumerate(self._functions):
+            func_var_data = [self._var_data(v) for v in f.params]
+            table = get_table_string(func_var_data, var_column_map)
+            func_strings.append(f"{i} Name: {f.name} Source: {f.source}")
+            func_strings.append(textwrap.indent(table, "    "))
+        func_table = "\n".join(map(textwrap.indent, func_strings, repeat("  ")))
+        strings.append("Solver Equations".center(max(map(len, func_table.splitlines()))))
+        strings.append(func_table)
+        init_vals = self.label_x(self._x0)
+        strings.append("Initial Values".center(max(map(len, init_vals.splitlines()))))
+        strings.append(init_vals)
+        return "\n".join(strings)

--- a/src/pancad/utils/text_formatting.py
+++ b/src/pancad/utils/text_formatting.py
@@ -39,7 +39,7 @@ def get_table_string(data: list[dict] | dict,
 
         lengths = list(map(lambda s: len(str(s)), rows))
         column_width = max(column_width, *lengths)
-        rows = [f"{{{str(s)}: <{column_width}}}" for s in rows]
+        rows = [f"{str(s):<{column_width}}" for s in rows]
         if len(string_rows) == 0:
             string_rows = rows
         else:


### PR DESCRIPTION
# Summary

Added AntiAlignAxes, made AlignAxes' docstring explicit about it also applying to axes and not just coordinate systems, and Fixed. Began adding SystemSolver in pancad.utils.solvers to be able to update geometry systems based upon their constraints.

# Changes

1. Added AntiAlignAxes
2. Added Fixed
3. Made pancad.api.make_constraint able to create Fixed and AntiAlignAxes
4. Fixed bug with text_formatting.get_table_string that resulted from over nesting the f strings
5. Added solvers.SystemSolver to begin solving axis and point constraints
6. Made SystemSolver solve point-to-line coincident constraints and fixed constraints to test out concept in a sandbox script. No unittests added in this update. Sets up for and uses scipy's scipy.optimize.root function to solve the non-linear system of equations.
7. Made SystemSolver solve the internal constraints on an axis or line, including: the direction being a unit vector and ensuring the reference point is the point on the line closest to the origin.
8. Added SystemSolver dunders and label public functions to ease debugging in the future by being able to print reports of which vector indices correspond to which part of a variable used by an equation.
9. Added solver constants to be able to reference low level parts of geometry like specific vectors and points that are more specific than ConstraintReferences, and to be able to differentiate which residual category a particular equation falls into, like if a vector should be forced to be a unit vector.

Closes #211 