### PR TITLE
241 249 Implement Plane Internal Constraints and Point-Plane Coincident

### DIFF
--- a/src/pancad/constants/_solver_constants.py
+++ b/src/pancad/constants/_solver_constants.py
@@ -35,3 +35,7 @@ class ConstraintEquationName(StrEnum):
     """
     UNIT_VECTOR = auto()
     """This vector must be a unit vector."""
+    PLANE_REF_POINT = auto()
+    """Plane Reference Point position vector must be aligned or anti-aligned
+    with the plane's normal vector to be the point closest to the origin.
+    """

--- a/src/pancad/constants/_solver_constants.py
+++ b/src/pancad/constants/_solver_constants.py
@@ -27,6 +27,8 @@ class ConstraintEquationName(StrEnum):
     """Point to Point coincident."""
     POINT_LINE_COINCIDENT = auto()
     """Point to Axis or Axis to Point coincident."""
+    POINT_PLANE_COINCIDENT = auto()
+    """Point to Plane or Plane to Point coincident."""
     FIXED_POINT = auto()
     """A point that must be placed at a constant location."""
     LINE_REF_POINT = auto()
@@ -35,6 +37,8 @@ class ConstraintEquationName(StrEnum):
     """
     UNIT_VECTOR = auto()
     """This vector must be a unit vector."""
+    CODIRECTIONAL = auto()
+    """These two vectors must be codirectional."""
     PLANE_REF_POINT = auto()
     """Plane Reference Point position vector must be aligned or anti-aligned
     with the plane's normal vector to be the point closest to the origin.

--- a/src/pancad/geometry/plane.py
+++ b/src/pancad/geometry/plane.py
@@ -30,8 +30,8 @@ class Plane(AbstractGeometry):
         if not isinstance(point, Point):
             point = Point(point)
         self._axis = Axis(point, normal)
-        self._point_closest_to_origin = Plane._closest_to_origin(point,
-                                                                 self.normal)
+        self._point_closest_to_origin = Plane._closest_to_origin(point, self.normal)
+        self._axis.move_to_point(self._point_closest_to_origin)
         super().__init__({ConstraintReference.CORE: self})
 
     # Getters #

--- a/src/pancad/utils/solvers.py
+++ b/src/pancad/utils/solvers.py
@@ -176,6 +176,17 @@ def point_line_coincident_res(eq: ConstraintEquation, x: npt.NDArray) -> npt.NDA
     t_param = t_param[0]
     return np.array(direction) * t_param + np.array(ref_point) - np.array(point)
 
+def point_plane_coincident_res(eq: ConstraintEquation, x: npt.NDArray) -> npt.NDArray:
+    """Returns the residual for how close a point is to being coincident on a Plane."""
+    ref_point, normal, point = [x[slice(*p.get_slicer())] for p in eq.params]
+    return np.array([np.dot(normal, np.array(point) - np.array(ref_point))])
+
+def codirectional_res(eq: ConstraintEquation, x: npt.NDArray) -> npt.NDArray:
+    """Returns the residual for how close two vectors are to being codirectional."""
+    vector_1, vector_2 = [x[slice(*p.get_slicer())] for p in eq.params]
+    dot_product = np.dot(vector_1, vector_2)
+    return np.array([dot_product - abs(dot_product)])
+
 def fixed_point_res(eq: ConstraintEquation, x: npt.NDArray) -> npt.NDArray:
     """Returns the residual for how close a fixed point is to its required location."""
     position_slice = slice(*eq.params[0].get_slicer())
@@ -186,7 +197,9 @@ RESIDUAL_FUNCS = {
     CEN.LINE_REF_POINT: line_ref_point_res,
     CEN.PLANE_REF_POINT: plane_ref_point_res,
     CEN.POINT_LINE_COINCIDENT: point_line_coincident_res,
+    CEN.POINT_PLANE_COINCIDENT: point_plane_coincident_res,
     CEN.FIXED_POINT: fixed_point_res,
+    CEN.CODIRECTIONAL: codirectional_res,
 }
 
 @dataclasses.dataclass
@@ -228,7 +241,7 @@ class ConstraintEquation:
     name: CEN
     params: list[ConstraintVariable] = dataclasses.field(repr=False)
     delim: str = dataclasses.field(repr=False)
-    x0: list[Real]
+    x0: list[Real] = dataclasses.field(repr=False)
 
     @property
     def key(self) -> str:
@@ -276,6 +289,10 @@ class SystemSolver:
             Levenberg-Marquardt (lm). See scipy.optimize.root for other options.
         """
         return find_root(self.fun, self._x0, method=method, **kwargs)
+
+    def get_initial(self) -> list[Real]:
+        """Returns the initial input vector to feed to the non-linear solver."""
+        return self._x0
 
     def update(self, new_x: npt.NDArray) -> None:
         """Updates all the variables in the system to a new vector value."""
@@ -389,6 +406,16 @@ class SystemSolver:
             ]
             func = ConstraintEquation(constraint.uid, CEN.POINT_LINE_COINCIDENT,
                                       params, self._delim, self._x0)
+        elif geo_types == {Plane, Point}:
+            plane = next(g for g in constraint.get_geometry() if isinstance(g, Plane))
+            point = next(g for g in constraint.get_geometry() if isinstance(g, Point))
+            params = [
+                self._get_var(plane, CVN.REF_POINT),
+                self._get_var(plane, CVN.NORMAL),
+                self._get_var(point, CVN.LOCATION),
+            ]
+            func = ConstraintEquation(constraint.uid, CEN.POINT_PLANE_COINCIDENT,
+                                      params, self._delim, self._x0)
         elif geo_types == {Point}:
             # Both are points
             raise NotImplementedError("Point to point not completed yet")
@@ -437,8 +464,9 @@ class SystemSolver:
     def _plane(self, geometry: Plane) -> None:
         geo_vars = [v for v in self._variables if v.source == geometry.uid]
         func_param_map = {
-            CEN.PLANE_REF_POINT: [CVN.NORMAL, CVN.REF_POINT],
-            CEN.UNIT_VECTOR: [CVN.NORMAL]
+            CEN.PLANE_REF_POINT: [CVN.REF_POINT, CVN.NORMAL],
+            CEN.UNIT_VECTOR: [CVN.NORMAL],
+            CEN.CODIRECTIONAL: [CVN.REF_POINT, CVN.NORMAL],
         }
         for name, params in func_param_map.items():
             func = ConstraintEquation(geometry.uid,
@@ -537,6 +565,7 @@ def update_variable(var: ConstraintVariable, new_x: npt.NDArray) -> None:
         CVN.DIRECTION: _update_direction,
         CVN.LOCATION: _update_location,
         CVN.REF_POINT: _update_ref_point,
+        CVN.NORMAL: _update_normal,
         CVN.PARAMETER: lambda element, x: None, # No update needed, ignore.
     }
     new_value = new_x[slice(*var.get_slicer())]
@@ -547,6 +576,9 @@ def _update_location(geometry: Point, value: npt.NDArray) -> None:
 
 def _update_direction(geometry: Axis | Line,  value: npt.NDArray) -> None:
     geometry.direction = value
+
+def _update_normal(geometry: Plane, value: npt.NDArray) -> None:
+    geometry.normal = value
 
 def _update_ref_point(geometry: Axis | Line | Plane, value: npt.NDArray) -> None:
     geometry.move_to_point(value)

--- a/src/pancad/utils/solvers.py
+++ b/src/pancad/utils/solvers.py
@@ -20,6 +20,7 @@ from pancad.constraints.state_constraint import Coincident
 from pancad.constraints.snapto import Fixed
 from pancad.geometry.line_segment import LineSegment
 from pancad.geometry.line import Axis, Line
+from pancad.geometry.plane import Plane
 from pancad.geometry.point import Point
 from pancad.utils.pancad_types import FitBox2D
 from pancad.utils.text_formatting import get_table_string
@@ -153,6 +154,15 @@ def line_ref_point_res(eq: ConstraintEquation, x: npt.NDArray) -> npt.NDArray:
     point, direction = [x[slice(*p.get_slicer())] for p in eq.params]
     return np.array([np.dot(direction, point)])
 
+def plane_ref_point_res(eq: ConstraintEquation, x: npt.NDArray) -> npt.NDArray:
+    """Returns the residual for how close a plane's reference point is to being the
+    closest to the origin point.
+    """
+    point, normal = [x[slice(*p.get_slicer())] for p in eq.params]
+    return np.array(
+        [np.linalg.norm(point) * np.linalg.norm(normal) - np.abs(np.dot(point, normal))]
+    )
+
 def unit_vector_res(eq: ConstraintEquation, x: npt.NDArray) -> npt.NDArray:
     """Returns the residual for how close a vector is to being a unit vector."""
     vector = x[slice(*eq.params[0].get_slicer())]
@@ -174,6 +184,7 @@ def fixed_point_res(eq: ConstraintEquation, x: npt.NDArray) -> npt.NDArray:
 RESIDUAL_FUNCS = {
     CEN.UNIT_VECTOR: unit_vector_res,
     CEN.LINE_REF_POINT: line_ref_point_res,
+    CEN.PLANE_REF_POINT: plane_ref_point_res,
     CEN.POINT_LINE_COINCIDENT: point_line_coincident_res,
     CEN.FIXED_POINT: fixed_point_res,
 }
@@ -422,6 +433,21 @@ class SystemSolver:
                                       self._x0)
             self._functions.append(func)
 
+    @_add_geometry_funcs.register
+    def _plane(self, geometry: Plane) -> None:
+        geo_vars = [v for v in self._variables if v.source == geometry.uid]
+        func_param_map = {
+            CEN.PLANE_REF_POINT: [CVN.NORMAL, CVN.REF_POINT],
+            CEN.UNIT_VECTOR: [CVN.NORMAL]
+        }
+        for name, params in func_param_map.items():
+            func = ConstraintEquation(geometry.uid,
+                                      name,
+                                      [v for v in geo_vars if v.name in params],
+                                      self._delim,
+                                      self._x0)
+            self._functions.append(func)
+
     @singledispatchmethod
     def _add_geometry_variables(self, geometry: AbstractGeometry) -> None:
         """Adds a geometry's internal variables to the variable list."""
@@ -447,6 +473,18 @@ class SystemSolver:
                                       len(self._x0), self._delim, geometry)
         self._x0.extend(variable.initial)
         self._variables.append(variable)
+
+    @_add_geometry_variables.register
+    def _plane_vars(self, geometry: Plane) -> None:
+        values = {
+            CVN.NORMAL: geometry.normal,
+            CVN.REF_POINT: geometry.reference_point.cartesian,
+        }
+        for name, vector in values.items():
+            variable = ConstraintVariable(geometry.uid, name, vector,
+                                          len(self._x0), self._delim, geometry)
+            self._x0.extend(variable.initial)
+            self._variables.append(variable)
 
     @staticmethod
     def _var_data(var: ConstraintVariable) -> dict[str, str | SpaceVector | Real]:
@@ -510,5 +548,5 @@ def _update_location(geometry: Point, value: npt.NDArray) -> None:
 def _update_direction(geometry: Axis | Line,  value: npt.NDArray) -> None:
     geometry.direction = value
 
-def _update_ref_point(geometry: Axis | Line, value: npt.NDArray) -> None:
+def _update_ref_point(geometry: Axis | Line | Plane, value: npt.NDArray) -> None:
     geometry.move_to_point(value)

--- a/tests/test_utils/test_system_solver.py
+++ b/tests/test_utils/test_system_solver.py
@@ -1,0 +1,54 @@
+"""Tests for pancad's system constraint solving systems."""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+import pytest
+
+from pancad.api import Axis, Point, ThreeDSketchSystem, make_constraint, SketchConstraint as SC
+from pancad.utils.solvers import SystemSolver
+
+if TYPE_CHECKING:
+    from numbers import Real
+
+    from pancad.abstract import AbstractGeometrySystem
+    from pancad.utils.pancad_types import SpaceVector
+
+def _axis_to_2_pts(ref_pt: SpaceVector, direct: SpaceVector, p1: SpaceVector, p2: SpaceVector
+                   ) -> tuple[ThreeDSketchSystem, ThreeDSketchSystem]:
+    """Generates a pair of an unsolved system with an Axis coincident to two fixed points and the
+    solved version of the system.
+    """
+    initial = [Axis(ref_pt, direct), Point(p1), Point(p2)]
+    solved = [Axis(p1, np.array(p2) - np.array(p1)), Point(p1), Point(p2)]
+    constraints = []
+    for axis, point_1, point_2 in [initial, solved]:
+        constraints.append(
+            [
+                make_constraint(SC.COINCIDENT, axis, point_1),
+                make_constraint(SC.COINCIDENT, axis, point_2),
+                make_constraint(SC.FIXED, point_1),
+                make_constraint(SC.FIXED, point_2),
+            ]
+        )
+    return ThreeDSketchSystem(initial, constraints[0]), ThreeDSketchSystem(solved, constraints[1])
+
+@pytest.mark.parametrize(
+    "initial, expected",
+    [
+        pytest.param(*_axis_to_2_pts((0,0,1), (1,0,0), (0,0,0), (1,0,0)),
+                     id="0,0,1-x-aligned_to_x"),
+        pytest.param(*_axis_to_2_pts((0,0,1), (1,0,0), (0,0,0), (1,1,1)),
+                     id="0,0,1-x-aligned_to_direct1,1,1"),
+    ]
+)
+def test_solve_system(initial: AbstractGeometrySystem, expected: AbstractGeometrySystem):
+    """Tests that SystemSolver can solve the constraints in the initial system and output the
+    expected system.
+    """
+    solver = SystemSolver(initial)
+    solution = solver.solve()
+    solver.update(solution.x)
+    print(solver.label_x(solution.x))
+    assert initial.is_equal(expected)

--- a/tests/test_utils/test_system_solver.py
+++ b/tests/test_utils/test_system_solver.py
@@ -5,15 +5,17 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 import pytest
+from pprint import pp
 
-from pancad.api import Axis, Point, ThreeDSketchSystem, make_constraint, SketchConstraint as SC
+from pancad.api import (Axis, Point, Plane, ThreeDSketchSystem,
+                        make_constraint, SketchConstraint as SC)
 from pancad.utils.solvers import SystemSolver
 
 if TYPE_CHECKING:
     from numbers import Real
 
     from pancad.abstract import AbstractGeometrySystem
-    from pancad.utils.pancad_types import SpaceVector
+    from pancad.utils.pancad_types import SpaceVector, Space3DVector
 
 def _axis_to_2_pts(ref_pt: SpaceVector, direct: SpaceVector, p1: SpaceVector, p2: SpaceVector
                    ) -> tuple[ThreeDSketchSystem, ThreeDSketchSystem]:
@@ -34,13 +36,45 @@ def _axis_to_2_pts(ref_pt: SpaceVector, direct: SpaceVector, p1: SpaceVector, p2
         )
     return ThreeDSketchSystem(initial, constraints[0]), ThreeDSketchSystem(solved, constraints[1])
 
+def _plane_to_3_pts(ref_pt: Space3DVector, normal: Space3DVector,
+                    pts: tuple[Space3DVector, Space3DVector, Space3DVector]
+                    ) -> tuple[ThreeDSketchSystem, ThreeDSketchSystem]:
+    """Generates a pair of an unsolved system with a Plane coincident to three fixed points and
+    the solved version of the system.
+    """
+    initial = [Point(p) for p in pts]
+    initial.append(Plane(ref_pt, normal))
+    p1, p2, p3 = pts
+    solved_normal = np.cross(np.array(p2) - np.array(p1), np.array(p3) - np.array(p1))
+    solved = [Point(p) for p in pts]
+    solved.append(Plane(p1, solved_normal))
+    print(pts)
+    print(solved[3].reference_axis.reference_point)
+    constraints = []
+    for point_1, point_2, point_3, plane in [initial, solved]:
+        constraints.append(
+            [
+                make_constraint(SC.FIXED, point_1),
+                make_constraint(SC.FIXED, point_2),
+                make_constraint(SC.FIXED, point_3),
+                make_constraint(SC.COINCIDENT, plane, point_1),
+                make_constraint(SC.COINCIDENT, plane, point_2),
+                make_constraint(SC.COINCIDENT, plane, point_3),
+            ]
+        )
+    return ThreeDSketchSystem(initial, constraints[0]), ThreeDSketchSystem(solved, constraints[1])
+
 @pytest.mark.parametrize(
     "initial, expected",
     [
         pytest.param(*_axis_to_2_pts((0,0,1), (1,0,0), (0,0,0), (1,0,0)),
-                     id="0,0,1-x-aligned_to_x"),
+                     id="2-pt-coincident-Axis(0,0,1)(1,0,0)-to-x-axis-aligned"),
         pytest.param(*_axis_to_2_pts((0,0,1), (1,0,0), (0,0,0), (1,1,1)),
-                     id="0,0,1-x-aligned_to_direct1,1,1"),
+                     id="2-pt-coincident-Axis(0,0,1)(1,0,0)-to-(0,0,0)(1,1,1)"),
+        pytest.param(*_plane_to_3_pts((0,0,0), (0,0,1), ((0,0,1), (1,0,1), (0,1,1))),
+                     id="3-pt-coincident-Plane-XY-to-Plane-XY-plus-1-z"),
+        pytest.param(*_plane_to_3_pts((0,0,0), (0,0,1), ((2,0,0), (0,2,0), (0,0,2))),
+                     id="3-pt-coincident-Plane-XY-to-all-2-away"),
     ]
 )
 def test_solve_system(initial: AbstractGeometrySystem, expected: AbstractGeometrySystem):
@@ -48,7 +82,12 @@ def test_solve_system(initial: AbstractGeometrySystem, expected: AbstractGeometr
     expected system.
     """
     solver = SystemSolver(initial)
+    print("\nInitial Input Vector")
+    print(solver.label_x(solver.get_initial()))
+    print("Initial Residuals")
+    print(solver.label_fun(solver.fun(solver.get_initial())))
     solution = solver.solve()
     solver.update(solution.x)
+    print("Solution Vector")
     print(solver.label_x(solution.x))
     assert initial.is_equal(expected)

--- a/tests/test_utils/test_system_solver.py
+++ b/tests/test_utils/test_system_solver.py
@@ -75,6 +75,8 @@ def _plane_to_3_pts(ref_pt: Space3DVector, normal: Space3DVector,
                      id="3-pt-coincident-Plane-XY-to-Plane-XY-plus-1-z"),
         pytest.param(*_plane_to_3_pts((0,0,0), (0,0,1), ((2,0,0), (0,2,0), (0,0,2))),
                      id="3-pt-coincident-Plane-XY-to-all-2-away"),
+        pytest.param(*_plane_to_3_pts((0,0,1), (0,0,1), ((0,0,0), (0,1,0), (0,0,1))),
+                     id="3-pt-coincident-Plane-XY-plus-1-z-to-YZ-Plane"),
     ]
 )
 def test_solve_system(initial: AbstractGeometrySystem, expected: AbstractGeometrySystem):
@@ -90,4 +92,6 @@ def test_solve_system(initial: AbstractGeometrySystem, expected: AbstractGeometr
     solver.update(solution.x)
     print("Solution Vector")
     print(solver.label_x(solution.x))
+    print("System Geometry")
+    print(initial.geometry)
     assert initial.is_equal(expected)


### PR DESCRIPTION
# Summary

Added the ability to add Plane internal constraints and Plane-to-Point coincident constraints to SystemSolver. Added the first unittests for SystemSolver and fixed a bug in the initialization of Plane's reference axis.

# Changes

1. Added internal constraints for Planes including: Normal vector must be a unit vector, plane reference point vector and normal vector must be parallel or anti-parallel, and the plane normal must be in the same direction as the reference point vector.
2. NOTE: The last internal plane constraint may need to be replaced or overridden by other constraints going forward to avoid over-constraining systems.
3. Added coincident constraints between points and planes to enable testing the plane internal constraints on a fully constrained system.
4. Added unit tests for solving line and plane coincident constraints to points.
5. Fixed a bug in Plane where the reference point of the Plane's reference axis was not updated to go through the plane's reference point, causing is_equal to fail in unit tests.
6. Added solver constants for Point-Plane coincidence, Plane reference points, and codirectionality.

Closes #241 and #249