### PR TITLE
257 Fixed Axis and Plane Constraints

### DIFF
--- a/src/pancad/constants/_solver_constants.py
+++ b/src/pancad/constants/_solver_constants.py
@@ -29,8 +29,8 @@ class ConstraintEquationName(StrEnum):
     """Point to Axis or Axis to Point coincident."""
     POINT_PLANE_COINCIDENT = auto()
     """Point to Plane or Plane to Point coincident."""
-    FIXED_POINT = auto()
-    """A point that must be placed at a constant location."""
+    FIXED_VECTOR = auto()
+    """A vector that must be held in a constant direction."""
     LINE_REF_POINT = auto()
     """Axis/Line Reference Point position vector must be perpendicular to the
     Axis/Line direction to be the point closest to the origin.

--- a/src/pancad/utils/solvers.py
+++ b/src/pancad/utils/solvers.py
@@ -187,8 +187,8 @@ def codirectional_res(eq: ConstraintEquation, x: npt.NDArray) -> npt.NDArray:
     dot_product = np.dot(vector_1, vector_2)
     return np.array([dot_product - abs(dot_product)])
 
-def fixed_point_res(eq: ConstraintEquation, x: npt.NDArray) -> npt.NDArray:
-    """Returns the residual for how close a fixed point is to its required location."""
+def fixed_vector_res(eq: ConstraintEquation, x: npt.NDArray) -> npt.NDArray:
+    """Returns the residual for how close a fixed vector is to its required direction."""
     position_slice = slice(*eq.params[0].get_slicer())
     return np.array(x[position_slice]) - np.array(eq.x0[position_slice])
 
@@ -198,7 +198,7 @@ RESIDUAL_FUNCS = {
     CEN.PLANE_REF_POINT: plane_ref_point_res,
     CEN.POINT_LINE_COINCIDENT: point_line_coincident_res,
     CEN.POINT_PLANE_COINCIDENT: point_plane_coincident_res,
-    CEN.FIXED_POINT: fixed_point_res,
+    CEN.FIXED_VECTOR: fixed_vector_res,
     CEN.CODIRECTIONAL: codirectional_res,
 }
 
@@ -257,12 +257,6 @@ class SystemSolver:
     and updates its geometry to meet them.
     """
     _delim = "_"
-    _func_map = {
-        CEN.UNIT_VECTOR: unit_vector_res,
-        CEN.LINE_REF_POINT: line_ref_point_res,
-        CEN.POINT_LINE_COINCIDENT: point_line_coincident_res,
-        CEN.FIXED_POINT: fixed_point_res,
-    }
 
     def __init__(self, system: AbstractGeometrySystem) -> None:
         self._system = system
@@ -430,7 +424,7 @@ class SystemSolver:
         geo = constraint.get_geometry()[0]
         if isinstance(geo, Point):
             params = [self._get_var(geo, CVN.LOCATION)]
-            func = ConstraintEquation(constraint.uid, CEN.FIXED_POINT,
+            func = ConstraintEquation(constraint.uid, CEN.FIXED_VECTOR,
                                       params, self._delim, self._x0)
         else:
             msg = f"Fixed relation for {geo} is not supported and/or may be invalid"

--- a/src/pancad/utils/solvers.py
+++ b/src/pancad/utils/solvers.py
@@ -422,14 +422,20 @@ class SystemSolver:
     @_add_constraint.register
     def _fixed(self, constraint: Fixed) -> None:
         geo = constraint.get_geometry()[0]
-        if isinstance(geo, Point):
-            params = [self._get_var(geo, CVN.LOCATION)]
-            func = ConstraintEquation(constraint.uid, CEN.FIXED_VECTOR,
-                                      params, self._delim, self._x0)
-        else:
+        vector_name_map = {
+            Point: [CVN.LOCATION],
+            Axis: [CVN.REF_POINT, CVN.DIRECTION],
+            Plane: [CVN.REF_POINT, CVN.NORMAL],
+        }
+        try:
+            vector_names = vector_name_map[type(geo)]
+        except KeyError as exc:
             msg = f"Fixed relation for {geo} is not supported and/or may be invalid"
-            raise NotImplementedError(msg)
-        self._functions.append(func)
+            raise NotImplementedError(msg) from exc
+
+        for v in [self._get_var(geo, n) for n in vector_names]:
+            eq = ConstraintEquation(constraint.uid, CEN.FIXED_VECTOR, [v], self._delim, self._x0)
+            self._functions.append(eq)
 
     @singledispatchmethod
     def _add_geometry_funcs(self, geometry: AbstractGeometry) -> None:

--- a/tests/test_utils/test_system_solver.py
+++ b/tests/test_utils/test_system_solver.py
@@ -64,6 +64,20 @@ def _plane_to_3_pts(ref_pt: Space3DVector, normal: Space3DVector,
         )
     return ThreeDSketchSystem(initial, constraints[0]), ThreeDSketchSystem(solved, constraints[1])
 
+def _fixed_3d_system() -> tuple[ThreeDSketchSystem, ThreeDSketchSystem]:
+    """Generates a fixed system containing at least one of each geometry that can be fixed."""
+    initial = [
+        Point(1, 1, 1),
+        Axis((0, 0, 0), (1, 1, 1)),
+        Plane((0, 0, 0), (0, 0, 1)),
+    ]
+    solved = [g.copy() for g in initial]
+    systems = []
+    for geometry in [initial, solved]:
+        constraints = [make_constraint(SC.FIXED, g) for g in geometry]
+        systems.append(ThreeDSketchSystem(geometry, constraints))
+    return tuple(systems)
+
 @pytest.mark.parametrize(
     "initial, expected",
     [
@@ -77,6 +91,7 @@ def _plane_to_3_pts(ref_pt: Space3DVector, normal: Space3DVector,
                      id="3-pt-coincident-Plane-XY-to-all-2-away"),
         pytest.param(*_plane_to_3_pts((0,0,1), (0,0,1), ((0,0,0), (0,1,0), (0,0,1))),
                      id="3-pt-coincident-Plane-XY-plus-1-z-to-YZ-Plane"),
+        pytest.param(*_fixed_3d_system(), id="fixed-3d-system"),
     ]
 )
 def test_solve_system(initial: AbstractGeometrySystem, expected: AbstractGeometrySystem):


### PR DESCRIPTION
# Summary

Added the ability to fix axes and planes into place inside geometry systems. Refactored previous fix relation function to use a dictionary that can be added to rather than a large if-else block.

# Changes

1. Changed FIXED_POINT constant to FIXED_VECTOR
2. Removed unused _func_map on SystemSolver
3. Refactored fixed dispatch function to collect which vector variables are being held constant rather than fixing in each expression statement.
4. Added test for a fully fixed 3D system with all currently possible fixed geometry.