### PR TITLE
Plane to Line Coincident

### DIFF
--- a/src/pancad/constants/_solver_constants.py
+++ b/src/pancad/constants/_solver_constants.py
@@ -33,17 +33,25 @@ class ConstraintEquationName(StrEnum):
     POINT_LINE_COINCIDENT = auto()
     """Point to Axis or Axis to Point coincident."""
 
+    POINT_LINE_DISTANCE = auto()
+    """Distance from a Axis or Line to a Point."""
+
     POINT_PLANE_COINCIDENT = auto()
     """Point to Plane or Plane to Point coincident."""
-
-    PLANE_PLANE_COINCIDENT = auto()
-    """Plane to Plane coincident."""
 
     POINT_PLANE_DISTANCE = auto()
     """Distance from a plane to a point."""
 
+    PLANE_LINE_COINCIDENT = auto()
+    """Line or Axis to Plane coincident."""
+
     PLANE_LINE_DISTANCE = auto()
-    """Distance from a plane to a line. Causes the plane and the point """
+    """Distance from a plane to a line. Causes the plane and the point to have an implied
+    parallel constraint so that the distance can be well defined.
+    """
+
+    PLANE_PLANE_COINCIDENT = auto()
+    """Plane to Plane coincident."""
 
     PLANE_PLANE_DISTANCE = auto()
     """The distance from one Plane to another Plane. Causes the Planes to have
@@ -52,9 +60,6 @@ class ConstraintEquationName(StrEnum):
 
     LINE_LINE_COINCIDENT = auto()
     """Line to Line Coincident."""
-
-    FIXED_VECTOR = auto()
-    """A vector that must be held in a constant direction."""
 
     LINE_REF_POINT = auto()
     """Axis/Line Reference Point position vector must be perpendicular to the

--- a/src/pancad/constants/_solver_constants.py
+++ b/src/pancad/constants/_solver_constants.py
@@ -39,6 +39,12 @@ class ConstraintEquationName(StrEnum):
     PLANE_PLANE_COINCIDENT = auto()
     """Plane to Plane coincident."""
 
+    POINT_PLANE_DISTANCE = auto()
+    """Distance from a plane to a point."""
+
+    PLANE_LINE_DISTANCE = auto()
+    """Distance from a plane to a line. Causes the plane and the point """
+
     PLANE_PLANE_DISTANCE = auto()
     """The distance from one Plane to another Plane. Causes the Planes to have
     an implied parallel constraint so that the distance can be well defined.
@@ -68,7 +74,10 @@ class ConstraintEquationName(StrEnum):
     """These two vectors must be antiparallel."""
 
     PARALLEL = auto()
-    """These two vectors must be either parallel (i.e., codirectional OR antiparallel)."""
+    """These two vectors must be parallel (i.e., codirectional OR antiparallel)."""
+
+    PERPENDICULAR = auto()
+    """These two vectors must be perpendicular."""
 
     PLANE_REF_POINT = auto()
     """Plane Reference Point position vector must be aligned or anti-aligned

--- a/src/pancad/utils/solver_residuals.py
+++ b/src/pancad/utils/solver_residuals.py
@@ -57,6 +57,28 @@ def get_3_plane_points(point: npt.NDArray, normal: npt.NDArray
     points.extend([points[0] + vec, points[0] + np.cross(normal, vec)])
     return points
 
+def get_plane_to_point_distance(plane_point: npt.NDArray, normal: npt.NDArray,
+                                point: npt.NDArray) -> np.float64:
+    """Returns the distance from the plane to the point.
+
+    :param plane_point: A point position vector on the plane.
+    :param normal: The plane's normal vector.
+    :param point: An arbitrary point position vector.
+    :returns: The distance from the point to the plane. Negative when the point is opposite of the
+        plane's normal vector.
+    :raises ValueError: When the normal vector is a zero vector.
+    """
+    try:
+        with np.errstate(divide="raise", invalid="raise"):
+            unit_normal = normal / np.linalg.norm(normal) # Will error when normal vector is zero.
+    except FloatingPointError as exc:
+        raise ValueError("Plane's normal vector cannot be a zero vector") from exc
+    # Find the vector from plane's point to the point and take the portion of it aligned with the
+    # plane's normal vector.
+    distance_vector = unit_normal * np.dot(unit_normal, point - plane_point)
+    # Make the norm positive if it's in the direction of the normal using dot product sign.
+    return np.copysign(np.linalg.norm(distance_vector), np.dot(distance_vector, unit_normal))
+
 def get_unique_vector(vector: npt.NDArray) -> npt.NDArray:
     """Checks the vector against unique direction rules and inverts it if any are violated.
 
@@ -156,13 +178,17 @@ def equal_vector(v1: npt.NDArray, v2: npt.NDArray) -> npt.NDArray:
     """
     return v1 - v2
 
-def perpendicular(v1: npt.NDArray, v2: npt.NDArray,
-                  zero_atol: np.float64=np.float64(1e-16)) -> np.float64:
+def perpendicular(v1: npt.NDArray, v2: npt.NDArray) -> np.float64:
     """Calculates how close two vectors are to being perpendicular to each other."""
-    norm1, norm2 = map(np.linalg.norm, (v1, v2))
-    if any(np.isclose(n, 0, atol=zero_atol) for n in (norm1, norm2)):
-        raise ValueError("Cannot check whether a zero vector is perpendicular")
-    return np.dot(v1, v2) / (np.linalg.norm(v1) * np.linalg.norm(v2))
+    n1, n2 = map(np.linalg.norm, (v1, v2))
+    try:
+        with np.errstate(divide="raise", invalid="raise"):
+            # Normalize to reduce round-off by making sure vectors are the same magnitude.
+            # nv1, nv2 = map(lambda v: v / np.linalg.norm(v), (v1, v2))
+            return np.dot(v1, v2) / (n1 * n2)
+    except FloatingPointError as exc:
+        msg = f"Cannot normalize, one of the vectors is likely a zero vector: {v1}, {v2}"
+        raise ValueError(msg) from exc
 
 def point_line_distance(line_pt: npt.NDArray, direction: npt.NDArray,
                         pt: npt.NDArray, distance: np.float64) -> np.float64:
@@ -181,21 +207,22 @@ point_line_coincident = partial(point_line_distance, distance=np.float64(0))
 point_line_coincident.__doc__ = """
     Calculates how close a point is to being on a line.
 
-    :param ref_pt: The line's closest to the origin reference point position vector.
-    :param direction: The line's direction vector.
+    :param line_pt: A point on the line.
+    :param direction: A vector in the direction of the line.
     :param pt: The point's position vector.
 """.strip()
 
-def point_plane_distance(pln_pt: npt.NDArray, normal: npt.NDArray,
-                         pt: npt.NDArray, distance: np.float64) -> np.float64:
+def point_plane_distance(plane_point: npt.NDArray, normal: npt.NDArray,
+                         point: npt.NDArray, distance: np.float64) -> np.float64:
     """Calculates how close a point is to being a specified closest distance from a plane.
 
-    :param pln_pt: A point on the plane.
+    :param plane_point: A point on the plane.
     :param normal: The plane's normal vector.
-    :param pt: The point's position vector.
+    :param point: The point's position vector.
     :param distance: The distance the point should be from the plane.
+    :raises ValueError: When the normal vector is a zero vector.
     """
-    return abs(np.dot(normal, pln_pt - pt) / np.linalg.norm(normal) - distance)
+    return get_plane_to_point_distance(plane_point, normal, point) - distance
 
 point_plane_coincident = partial(point_plane_distance, distance=np.float64(0))
 point_plane_coincident.__doc__ = """
@@ -206,31 +233,62 @@ point_plane_coincident.__doc__ = """
     :param pt: The point's position vector.
 """.strip()
 
-def plane_plane_distance(p1: npt.NDArray, n1: npt.NDArray, p2: npt.NDArray, n2: npt.NDArray,
+def plane_line_distance(plane_point: npt.NDArray, normal: npt.NDArray,
+                        line_point: npt.NDArray, direction: npt.NDArray,
+                        distance: np.float64) -> np.float64:
+    """Calculates how close a line is to being a specified distance from a plane. Also works on
+    axes.
+
+    :param plane_point: A point on the plane.
+    :param normal: The plane's normal vector.
+    :param line_point: A point on the line.
+    :param direction: A vector in the direction of the line.
+    :param distance: The distance the line should be from the plane.
+    :raises ValueError: When the normal vector is a zero vector.
+    """
+    distance_residuals = np.empty(2)
+    for i, point in enumerate((line_point, line_point + direction / np.linalg.norm(direction))):
+        distance_residuals[i] = point_plane_distance(plane_point, normal, point, distance)
+    return distance_residuals[np.argmax(abs(distance_residuals))]
+
+plane_line_coincident = partial(plane_line_distance, distance=np.float64(0))
+plane_line_coincident.__doc__ = """
+    Calculates how close a line or axis is to being on a plane.
+
+    :param pln_pt: The plane's closest to the origin reference point position vector.
+    :param normal: The plane's normal vector.
+    :param pt: The point's position vector.
+""".strip()
+
+def plane_plane_distance(point_1: npt.NDArray, normal_1: npt.NDArray,
+                         point_2: npt.NDArray, normal_2: npt.NDArray,
                          distance: np.float64) -> np.float64:
     """Calculates how close two planes are to being a specified distance from each other.
 
-    :param p1: A point on the first Plane.
-    :param n1: The normal vector of the first Plane.
-    :param p2: A point on the second Plane.
-    :param n2: The normal vector of the second Plane.
+    :param point_1: A point on the first Plane.
+    :param normal_1: The normal vector of the first Plane.
+    :param point_2: A point on the second Plane.
+    :param normal_2: The normal vector of the second Plane.
     :param distance: The required distance between the two planes. Positive in the direction of
         the first plane's normal vector.
     """
-    distances = []
-    # Enforce normal uniqueness since distance is independent of normal vector direction
-    un1, un2 = map(get_unique_vector, (n1, n2))
-    distances = np.empty(3)
-    for i, pt in enumerate(get_3_plane_points(p1, un1)):
+    # Enforce normal uniqueness to make the choice of plane points independent of normal direction
+    unique_normal_1, unique_normal_2 = map(get_unique_vector, (normal_1, normal_2))
+    distance_residuals = np.empty(3)
+    for i, arbitrary_plane_1_point in enumerate(get_3_plane_points(point_1, unique_normal_1)):
         try:
             with np.errstate(divide="raise", invalid="raise"):
-                proj_pt = pt + un1 * np.dot(un2, p2 - pt) / np.dot(un1, un2)
+                projected_point = (
+                    arbitrary_plane_1_point
+                    + unique_normal_1
+                    * np.dot(unique_normal_2, point_2 - arbitrary_plane_1_point)
+                    / np.dot(unique_normal_1, unique_normal_2)
+                )
         except FloatingPointError:
             # The normal vectors are perpendicular, so the effective distance is infinity.
             return np.inf
-        pt_to_proj = proj_pt - pt
-        distances[i] = np.copysign(np.linalg.norm(pt_to_proj), np.dot(un1, pt_to_proj))
-    return distances[np.argmax(abs(distances))] - distance
+        distance_residuals[i] = point_plane_distance(point_1, normal_1, projected_point, distance)
+    return distance_residuals[np.argmax(abs(distance_residuals))]
 
 plane_plane_coincident = partial(plane_plane_distance, distance=np.float64(0))
 plane_plane_coincident.__doc__ = """

--- a/src/pancad/utils/solver_residuals.py
+++ b/src/pancad/utils/solver_residuals.py
@@ -278,7 +278,7 @@ plane_line_coincident.__doc__ = """
 """.strip()
 
 _param_order_map[CEN.PLANE_LINE_DISTANCE] = (Plane, Axis, Line)
-_param_order_map[CEN.PLANE_LINE_DISTANCE] = _param_order_map[CEN.PLANE_LINE_DISTANCE]
+_param_order_map[CEN.PLANE_LINE_COINCIDENT] = _param_order_map[CEN.PLANE_LINE_DISTANCE]
 
 def plane_plane_distance(point_1: npt.NDArray, normal_1: npt.NDArray,
                          point_2: npt.NDArray, normal_2: npt.NDArray,
@@ -412,6 +412,7 @@ RESIDUAL_FUNCS = {
     CEN.CODIRECTIONAL: codirectional,
     CEN.ANTIPARALLEL: antiparallel,
     CEN.PARALLEL: parallel,
+    CEN.PERPENDICULAR: perpendicular,
     CEN.UNIQUE_VECTOR: unique_vector,
     CEN.NON_ZERO: non_zero_vector,
 }

--- a/src/pancad/utils/solver_residuals.py
+++ b/src/pancad/utils/solver_residuals.py
@@ -6,14 +6,22 @@ from __future__ import annotations
 from functools import partial
 from typing import TYPE_CHECKING
 
+import math
 import numpy as np
 
-from pancad.constants import SketchConstraint as SC
+from pancad.constants import SketchConstraint as SC, ConstraintEquationName as CEN
+
+from pancad.geometry.line import Axis, Line
+from pancad.geometry.plane import Plane
+from pancad.geometry.point import Point
 
 if TYPE_CHECKING:
-    from typing import Literal
+    from typing import Literal, Type
 
     import numpy.typing as npt
+
+    from pancad.abstract import PancadThing
+
 
 ################################################################################
 # Helpers
@@ -96,9 +104,16 @@ def get_unique_vector(vector: npt.NDArray) -> npt.NDArray:
             return vector
     return vector
 
+
+
 ################################################################################
 # Residuals
 ################################################################################
+
+_param_order_map = {}
+"""Mapping for ordering parameters by their geometry type for cases where the order matters.
+Any residual function where ordering does matter are omitted from the mapping.
+"""
 
 def unit_vector(vector: npt.NDArray) -> np.float64:
     """Calculates how far a vector is from being a unit vector."""
@@ -208,6 +223,9 @@ point_line_coincident.__doc__ = """
     :param pt: The point's position vector.
 """.strip()
 
+_param_order_map[CEN.POINT_LINE_DISTANCE] = (Axis, Line, Point)
+_param_order_map[CEN.POINT_LINE_COINCIDENT] = _param_order_map[CEN.POINT_LINE_DISTANCE]
+
 def point_plane_distance(plane_point: npt.NDArray, normal: npt.NDArray,
                          point: npt.NDArray, distance: np.float64) -> np.float64:
     """Calculates how close a point is to being a specified closest distance from a plane.
@@ -228,6 +246,9 @@ point_plane_coincident.__doc__ = """
     :param normal: The plane's normal vector.
     :param pt: The point's position vector.
 """.strip()
+
+_param_order_map[CEN.POINT_PLANE_DISTANCE] = (Plane, Point)
+_param_order_map[CEN.POINT_PLANE_COINCIDENT] = _param_order_map[CEN.POINT_PLANE_DISTANCE]
 
 def plane_line_distance(plane_point: npt.NDArray, normal: npt.NDArray,
                         line_point: npt.NDArray, direction: npt.NDArray,
@@ -255,6 +276,9 @@ plane_line_coincident.__doc__ = """
     :param normal: The plane's normal vector.
     :param pt: The point's position vector.
 """.strip()
+
+_param_order_map[CEN.PLANE_LINE_DISTANCE] = (Plane, Axis, Line)
+_param_order_map[CEN.PLANE_LINE_DISTANCE] = _param_order_map[CEN.PLANE_LINE_DISTANCE]
 
 def plane_plane_distance(point_1: npt.NDArray, normal_1: npt.NDArray,
                          point_2: npt.NDArray, normal_2: npt.NDArray,
@@ -352,3 +376,42 @@ def unique_vector(vector: npt.NDArray, zero_atol: np.float64=np.float64(1e-16)) 
         # Y is not close to 0, so return y residual.
         residuals.extend([y - abs(y), 0])
     return np.array(residuals)
+
+def get_param_sort_key(type_: Type[PancadThing],
+                   equation_name: CEN) -> float:
+    """Returns the parameter sorting key of the type for the named equation.
+
+    :param type_: The parameter's source type.
+    :param equation_name: The name of the equation to sort parameters for.
+    :raises ValueError: When provided a geometry type not in the equation's ordering list.
+    :returns: The index of the type in the ordering map's equation list. Returns infinity when the
+        equation is not in the ordering map.
+    """
+    try:
+        order = _param_order_map[equation_name]
+    except KeyError:
+        # Equation name not being in the ordering map indicates the parameters can be unordered.
+        return math.inf
+    try:
+        return order.index(type_)
+    except ValueError as exc:
+        exc.add_note(f"Type {type_} is not in the {equation_name} ordering list")
+        raise
+
+
+RESIDUAL_FUNCS = {
+    CEN.UNIT_VECTOR: unit_vector,
+    CEN.EQUAL_VECTOR: equal_vector,
+    CEN.LINE_REF_POINT: line_ref_point, # Line Ref Point Vector and Direction Perpendicularity
+    CEN.POINT_LINE_COINCIDENT: point_line_coincident,
+    CEN.POINT_PLANE_COINCIDENT: point_plane_coincident,
+    CEN.LINE_LINE_COINCIDENT: line_line_coincident,
+    CEN.PLANE_PLANE_COINCIDENT: plane_plane_coincident,
+    CEN.PLANE_LINE_COINCIDENT: plane_line_coincident,
+    CEN.PLANE_PLANE_DISTANCE: plane_plane_distance,
+    CEN.CODIRECTIONAL: codirectional,
+    CEN.ANTIPARALLEL: antiparallel,
+    CEN.PARALLEL: parallel,
+    CEN.UNIQUE_VECTOR: unique_vector,
+    CEN.NON_ZERO: non_zero_vector,
+}

--- a/src/pancad/utils/solver_residuals.py
+++ b/src/pancad/utils/solver_residuals.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 from functools import partial
 from typing import TYPE_CHECKING
-import warnings
 
 import numpy as np
 
@@ -133,16 +132,13 @@ def _direction(v1: npt.NDArray, v2: npt.NDArray,
                f" Expected {SC.CODIRECTIONAL}, {SC.ANTIPARALLEL}, or {SC.PARALLEL}")
         raise TypeError(msg) from exc
     if sign * dot > 0:
-        with warnings.catch_warnings():
-            # numpy will raise a warning from division by zero (inf) or zero divided by zero (NaN)
-            # Normalization cannot occur, so it's treated as an error rather than a warning.
-            warnings.filterwarnings("error")
-            try:
+        try:
+            with np.errstate(divide="raise", invalid="raise"):
                 return v1 / norm1 - sign * v2 / norm2
-            except RuntimeWarning as warn:
-                if not any(s in str(warn) for s in ("invalid value", "divide by zero")):
-                    # Ensure unexpected warnings are still raised.
-                    raise
+        except FloatingPointError as exc:
+            if not any(s in str(exc) for s in ("invalid value", "divide by zero")):
+                # Ensure unexpected warnings are still raised.
+                raise
     # sign * dot being less than or equal to 0 indicates the vectors are pointing in opposite
     # directions to the goal of being codirection or antiparallel. Return the difference to get
     # the solver to switch them.

--- a/src/pancad/utils/solvers.py
+++ b/src/pancad/utils/solvers.py
@@ -574,6 +574,8 @@ class SystemSolver:
         # without that extra constraint.
         parallel_combos = [
             # Normal and direction must be perpendicular for axis/line to plane parallism.
+            ({Axis, Plane}, CEN.PERPENDICULAR),
+            ({Line, Plane}, CEN.PERPENDICULAR),
             ({Plane}, CEN.PARALLEL),
         ]
         implied_var_map = {Plane: [CVN.NORMAL], Line: [CVN.DIRECTION], Axis: [CVN.DIRECTION]}

--- a/src/pancad/utils/solvers.py
+++ b/src/pancad/utils/solvers.py
@@ -587,13 +587,25 @@ class SystemSolver:
         combos = [
             ({Axis, Point}, CEN.POINT_LINE_COINCIDENT),
             ({Line, Point}, CEN.POINT_LINE_COINCIDENT),
-            ({Plane, Point}, CEN.POINT_PLANE_COINCIDENT),
             ({Axis}, CEN.LINE_LINE_COINCIDENT),
+            ({Line}, CEN.LINE_LINE_COINCIDENT),
+            ({Plane, Point}, CEN.POINT_PLANE_COINCIDENT),
+            ({Plane}, CEN.PLANE_PLANE_COINCIDENT),
         ]
         eq_map = {frozenset(c): partial(self._new_constraint_eq, eq=e, var_map=var_map)
                   for c, e in combos}
         self._add_equation(constraint, eq_map)
-        # TODO: Add plane and line implied parallel constraints and tests for coincident.
+
+        # Handle cases where the combo elements are implied to be parallel and can't be solved
+        # without that extra constraint.
+        parallel_combos = [
+            # Normal and direction must be perpendicular for axis/line to plane parallism.
+            ({Axis, Plane}, CEN.PERPENDICULAR),
+            ({Line, Plane}, CEN.PERPENDICULAR),
+            ({Plane}, CEN.PARALLEL),
+        ]
+        implied_var_map = {Plane: [CVN.NORMAL], Line: [CVN.DIRECTION], Axis: [CVN.DIRECTION]}
+        self._add_conditional_equation(constraint, parallel_combos, implied_var_map)
 
     @_add_constraint.register
     def _fixed(self, constraint: Fixed) -> None:

--- a/src/pancad/utils/solvers.py
+++ b/src/pancad/utils/solvers.py
@@ -16,7 +16,13 @@ from scipy.optimize import root as find_root
 from pancad.abstract import AbstractGeometry
 from pancad.constants import ConstraintVariableName as CVN, ConstraintEquationName as CEN
 
-from pancad.constraints.state_constraint import Coincident, Codirectional, Antiparallel, Parallel
+from pancad.constraints.state_constraint import (
+    Antiparallel,
+    Coincident,
+    Codirectional,
+    Parallel,
+    Perpendicular,
+)
 from pancad.constraints.distance import Distance
 from pancad.constraints.snapto import Fixed, Unique
 from pancad.geometry.line_segment import LineSegment
@@ -39,6 +45,7 @@ if TYPE_CHECKING:
     from pancad.utils.pancad_types import SpaceVector
 
     GeoCombo = frozenset[Type[AbstractGeometry]]
+    VariableMap = dict[Type[AbstractGeometry], list[CVN]]
 
 def get_length(segment: LineSegment,
                along: Literal["x", "y", "z"]=None) -> float:
@@ -528,6 +535,18 @@ class SystemSolver:
         self._add_equation(constraint, {frozenset({c}): func for c in var_map})
 
     @_add_constraint.register
+    def _perpendicular(self, constraint: Perpendicular) -> None:
+        var_map = {Axis: [CVN.DIRECTION], Plane: [CVN.NORMAL]}
+        combos = [
+            ({Axis}, CEN.PERPENDICULAR),
+            ({Axis, Plane}, CEN.PARALLEL),
+            ({Plane}, CEN.PERPENDICULAR),
+        ]
+        eq_map = {frozenset(c): partial(self._new_constraint_eq, eq=e, var_map=var_map)
+                  for c, e in combos}
+        self._add_equation(constraint, eq_map)
+
+    @_add_constraint.register
     def _unique(self, constraint: Unique) -> None:
         var_map = {Axis: [CVN.DIRECTION], Plane: [CVN.NORMAL]}
         func = partial(self._new_constraint_eq, eq=CEN.UNIQUE_VECTOR, var_map=var_map)
@@ -537,6 +556,8 @@ class SystemSolver:
     def _distance(self, constraint: Distance) -> None:
         var_map = {Plane: [CVN.REF_POINT, CVN.NORMAL]}
         combos = [
+            ({Axis, Plane}, CEN.PLANE_LINE_DISTANCE),
+            ({Line, Plane}, CEN.PLANE_LINE_DISTANCE),
             ({Plane}, CEN.PLANE_PLANE_DISTANCE),
         ]
         # Add distance equation.
@@ -544,11 +565,16 @@ class SystemSolver:
                                         constants={"distance": constraint.value})
                   for c, e in combos}
         self._add_equation(constraint, eq_map)
-        if {type(g) for g in constraint.get_geometry()} == {Plane}:
-            # Special Case: Planes must be parallel to have a meaningful distance between them.
-            func = partial(self._new_constraint_eq,
-                           eq=CEN.PARALLEL, var_map={Plane: [CVN.NORMAL]})
-            self._add_equation(constraint, {frozenset({Plane}): func})
+
+        # Handle cases where the combo elements are implied to be parallel.
+        parallel_combos = [
+            # Normal and direction must be perpendicular for axis/line to plane parallism.
+            ({Axis, Plane}, CEN.PERPENDICULAR),
+            ({Line, Plane}, CEN.PERPENDICULAR),
+            ({Plane}, CEN.PARALLEL),
+        ]
+        implied_var_map = {Plane: [CVN.NORMAL], Line: [CVN.DIRECTION], Axis: [CVN.DIRECTION]}
+        self._add_conditional_equation(constraint, parallel_combos, implied_var_map)
 
     @_add_constraint.register
     def _coincident(self, constraint: Coincident) -> None:
@@ -567,6 +593,7 @@ class SystemSolver:
         eq_map = {frozenset(c): partial(self._new_constraint_eq, eq=e, var_map=var_map)
                   for c, e in combos}
         self._add_equation(constraint, eq_map)
+        # TODO: Add plane and line implied parallel constraints and tests for coincident.
 
     @_add_constraint.register
     def _fixed(self, constraint: Fixed) -> None:
@@ -587,9 +614,13 @@ class SystemSolver:
         self._equations = [e for e in self._equations if e.element != geo]
 
     def _add_equation(self, constraint: AbstractConstraint,
-                           eq_map: dict[GeoCombo,
-                                        Callable[[AbstractConstraint], list[ConstraintEquation]]]
-                           ) -> None:
+                      eq_map: dict[GeoCombo,
+                                   Callable[[AbstractConstraint], list[ConstraintEquation]]]
+                      ) -> None:
+        """Adds an equation to the solver.
+
+        :raises NotImplementedError: When the constraint's geometry combo types are unsupported.
+        """
         types = frozenset(type(g) for g in constraint.get_geometry())
         try:
             func = eq_map[types]
@@ -599,10 +630,24 @@ class SystemSolver:
             raise NotImplementedError(msg) from exc
         self._equations.append(func(constraint))
 
+    def _add_conditional_equation(self, constraint: AbstractConstraint,
+                                  combos: list[tuple[set[AbstractGeometry], CEN]],
+                                  var_map: VariableMap) -> None:
+        """Adds an equation to the solver if the constraint's geometry combo is in the combo list.
+        Used to deal with implied constraints like when two planes need to be parallel to have a
+        distance between them.
+        """
+        types = frozenset(type(g) for g in constraint.get_geometry())
+        eq_map = {frozenset(c): partial(self._new_constraint_eq, eq=e, var_map=var_map)
+                  for c, e in combos}
+        if types in eq_map:
+            func = eq_map[types]
+            self._equations.append(func(constraint))
+
     def _new_constraint_eq(self,
                            constraint: AbstractConstraint,
                            eq: CEN,
-                           var_map: dict[Type[AbstractGeometry], list[CVN]],
+                           var_map: VariableMap,
                            constants: Optional[dict[str, np.float64]]=None,
                            ) -> ConstraintEquation:
         if constants is None:

--- a/src/pancad/utils/solvers.py
+++ b/src/pancad/utils/solvers.py
@@ -162,30 +162,9 @@ def _norm_with_zero(vector: npt.NDArray | SpaceVector) -> npt.NDArray:
     return np.array(vector) / norm
 
 
-
 ################################################################################
 # Residual Calculators
 ################################################################################
-
-
-RESIDUAL_FUNCS = {
-    CEN.UNIT_VECTOR: pcres.unit_vector,
-    CEN.EQUAL_VECTOR: pcres.equal_vector,
-    CEN.LINE_REF_POINT: pcres.line_ref_point,
-    # Line Reference Point Vector and Direction Perpendicularity
-    CEN.POINT_LINE_COINCIDENT: pcres.point_line_coincident,
-    CEN.POINT_PLANE_COINCIDENT: pcres.point_plane_coincident,
-    CEN.LINE_LINE_COINCIDENT: pcres.line_line_coincident,
-    CEN.PLANE_PLANE_COINCIDENT: pcres.plane_plane_coincident,
-    CEN.PLANE_PLANE_DISTANCE: pcres.plane_plane_distance,
-    CEN.FIXED_VECTOR: pcres.equal_vector,
-    # First vector must be held constant to a supplied initial vector
-    CEN.CODIRECTIONAL: pcres.codirectional,
-    CEN.ANTIPARALLEL: pcres.antiparallel,
-    CEN.PARALLEL: pcres.parallel,
-    CEN.UNIQUE_VECTOR: pcres.unique_vector,
-    CEN.NON_ZERO: pcres.non_zero_vector,
-}
 
 class ConstraintVariable:
     """A class for tracking variables used by constraint functions.
@@ -263,13 +242,7 @@ class ConstraintEquation:
                 param_values.append(p.value[0])
             else:
                 param_values.append(p.value)
-        if self.name == CEN.FIXED_VECTOR:
-            for p in self.params:
-                if len(p) == 1:
-                    param_values.append(p.initial[0])
-                else:
-                    param_values.append(p.initial)
-        result = RESIDUAL_FUNCS[self.name](*param_values, **self.constants)
+        result = pcres.RESIDUAL_FUNCS[self.name](*param_values, **self.constants)
         if isinstance(result, np.ndarray):
             return result
         return np.array([result])
@@ -590,6 +563,7 @@ class SystemSolver:
             ({Axis}, CEN.LINE_LINE_COINCIDENT),
             ({Line}, CEN.LINE_LINE_COINCIDENT),
             ({Plane, Point}, CEN.POINT_PLANE_COINCIDENT),
+            ({Plane, Line}, CEN.PLANE_LINE_COINCIDENT),
             ({Plane}, CEN.PLANE_PLANE_COINCIDENT),
         ]
         eq_map = {frozenset(c): partial(self._new_constraint_eq, eq=e, var_map=var_map)
@@ -600,8 +574,6 @@ class SystemSolver:
         # without that extra constraint.
         parallel_combos = [
             # Normal and direction must be perpendicular for axis/line to plane parallism.
-            ({Axis, Plane}, CEN.PERPENDICULAR),
-            ({Line, Plane}, CEN.PERPENDICULAR),
             ({Plane}, CEN.PARALLEL),
         ]
         implied_var_map = {Plane: [CVN.NORMAL], Line: [CVN.DIRECTION], Axis: [CVN.DIRECTION]}
@@ -672,6 +644,7 @@ class SystemSolver:
                 msg = f"Got unsupported geometry type {geo} for constraint {constraint}"
                 raise NotImplementedError(msg) from exc
             params.extend(self._get_var(geo, var) for var in geo_vars)
+        params.sort(key=lambda p: pcres.get_param_sort_key(type(p.element), eq))
         return ConstraintEquation(constraint, eq, params, constants)
 
     @singledispatchmethod

--- a/tests/test_utils/test_system_solver.py
+++ b/tests/test_utils/test_system_solver.py
@@ -62,6 +62,23 @@ def _perpendicular_planes(pln1: PlaneInputs, pln2: PlaneInputs,
     expected = _generate_system([Plane(*exppln), Plane(*pln2), Point(fix_pt)], cons)
     return initial, expected
 
+def _plane_intersection_line(line: LineInputs, plane_1: PlaneInputs, plane_2: PlaneInputs,
+                             expected_line: LineInputs) -> SystemTestPair:
+    """Generates a pair systems of 2 fixed planes and a line coincident to both of them."""
+    cons = [
+        (SC.COINCIDENT, (0, 1)),
+        (SC.COINCIDENT, (0, 2)),
+        (SC.FIXED, (1,)),
+        (SC.FIXED, (2,)),
+    ]
+    point, direction = line
+    initial = _generate_system([Line(Point(point), direction), Plane(*plane_1), Plane(*plane_2)],
+                               cons)
+    point, direction = expected_line
+    expected = _generate_system([Line(Point(point), direction), Plane(*plane_1), Plane(*plane_2)],
+                                cons)
+    return initial, expected
+
 def _coincident_planes(plane_1: PlaneInputs, plane_2: PlaneInputs,
                        expected_plane: PlaneInputs) -> SystemTestPair:
     """Generates a pair of systems for 1 fixed plane and a plane that is coincident to the fixed
@@ -184,34 +201,77 @@ def _2_planes_distance(fix_pln_vecs: tuple[Space3DVector, Space3DVector],
 @pytest.mark.parametrize(
     "initial, expected",
     [
+        ### Point-Line Coincident Tests
+        # Line starting with ref point (0,0,1) and in the x direction coincident with two fixed
+        # points at (0,0,0) and (1,0,0).
         pytest.param(*_line_to_2_pts((0,0,1), (1,0,0), (0,0,0), (1,0,0)),
                      id="2-pt-coincident-Line(0,0,1)(1,0,0)-to-x-axis-aligned"),
+        # Line starting with ref point (0,0,1) and in the x direction coincident with two fixed
+        # points at (0,0,0) and (1,1,1).
         pytest.param(*_line_to_2_pts((0,0,1), (1,0,0), (0,0,0), (1,1,1)),
                      id="2-pt-coincident-Line(0,0,1)(1,0,0)-to-(0,0,0)(1,1,1)"),
+
+        ### Plane-Point Coincident Tests
+        # Plane starting at ref point (0,0,0) with normal in the z direction coincident with 3
+        # points (0,0,1), (1,0,1), and (0,1,1).
         pytest.param(*_plane_to_3_pts((0,0,0), (0,0,1), ((0,0,1), (1,0,1), (0,1,1))),
                      id="3-pt-coincident-Plane-XY-to-Plane-XY-plus-1-z"),
+        # Plane starting at ref point (0,0,0) with normal in the z direction coincident with 3
+        # points (2,0,0), (0,2,0), and (0,0,2).
         pytest.param(*_plane_to_3_pts((0,0,0), (0,0,1), ((2,0,0), (0,2,0), (0,0,2))),
                      id="3-pt-coincident-Plane-XY-to-all-2-away"),
+        # Plane starting at ref point (0,0,0) with normal in the z direction coincident with 3
+        # points (0,0,0), (0,1,0), and (0,0,1).
         pytest.param(*_plane_to_3_pts((0,0,1), (0,0,1), ((0,0,0), (0,1,0), (0,0,1))),
                      id="3-pt-coincident-Plane-XY-plus-1-z-to-YZ-Plane"),
+
+        ### Fixed System Tests
+        # A system with one of each geometry fixed into place.
         pytest.param(*_fixed_3d_system(), id="fixed-3d-system"),
+
+        ### Axis-Axis Coincident with Codirectional Tests
+        # X Axis coincident to negative x axis.
         *_coincident_axis_duo(((0,0,0), (1,0,0)), ((0,0,0), (-1,0,0)), "axes-coincident-X-to-negX"),
+        # X Axis coincident to another X axis.
         *_coincident_axis_duo(((0,0,0), (1,0,0)), ((0,0,0), (1,0,0)), "axes-coincident-X-to-X"),
+        # X Axis coincident to Y axis.
         *_coincident_axis_duo(((0,0,0), (1,0,0)), ((0,0,0), (0,1,0)), "axes-coincident-X-to-Y"),
+        # X Axis coincident to Z axis.
         *_coincident_axis_duo(((0,0,0), (1,0,0)), ((0,0,0), (0,0,1)), "axes-coincident-X-to-Z"),
+        # An Axis with ref point (1,1,1) and direction in the x direction coincident to Y axis.
         *_coincident_axis_duo(((1,1,1), (1,0,0)), ((0,0,0), (0,1,0)), "axes-coincident-111-to-Y"),
+
+        ### Plane-Plane Distance Tests
+        # XY plane +10 units away from a fixed XY plane. (Fixed plane first arg)
         pytest.param(*_2_planes_distance(((0,0,0), (0,0,1)), ((0,0,0), (0,0,1)), 10),
                      id="plane-dist-xy-xy-10"),
+        # Plane at ref point (1,1,1) and direction (1,1,1) +10 units away from a fixed XY plane.
+        # (Fixed plane first arg)
         pytest.param(*_2_planes_distance(((0,0,0), (0,0,1)), ((1,1,1), (1,1,1)), 10),
                      id="plane-dist-xy-111-111pln-10"),
+        # Plane at ref point (0,0,0) and direction (1,1,1) +10 units away from a fixed XY plane.
+        # (Fixed plane first arg)
         pytest.param(*_2_planes_distance(((0,0,0), (0,0,1)), ((0,0,0), (1,1,1)), 10),
                      id="plane-dist-xy-000-111pln-10"),
+        # Plane at ref point (0,0,0) and direction (1,0,0) +10 units away from a fixed XY plane.
+        # (Fixed plane first arg). In other words: The planes start perpendicular.
         pytest.param(*_2_planes_distance(((0,0,0), (0,0,1)), ((0,0,0), (1,0,0)), 10),
                      id="plane-dist-xy-yz-10",
                      marks=pytest.mark.xfail(reason="Starting from perp planes not yet defined")),
+        # Plane at ref point (0,0,1) and direction in z direction coincident with XY plane.
         pytest.param(
             *_coincident_planes(((0,0,1), (0,0,1)), ((0,0,0), (0,0,1)), ((0,0,0), (0,0,1))),
             id="planes-coincident-xyp1z-to-xy"
+        ),
+        # Line starting with ref point (1,0,0) and in the z direction coincident with fixed YZ and
+        # XZ planes.
+        pytest.param(
+            *_plane_intersection_line(
+                ((1,0,0), (0,0,1)), # Line
+                ((0,0,0), (1,0,0)), ((0,0,0), (0,1,0)), # Planes
+                ((0,0,0), (0,0,1)) # Expected Line
+            ),
+            id="line-coincident-xz-and-yz-planes"
         ),
     ]
 )

--- a/tests/test_utils/test_system_solver.py
+++ b/tests/test_utils/test_system_solver.py
@@ -21,11 +21,46 @@ if TYPE_CHECKING:
 
     import numpy.typing as npt
 
-    from pancad.abstract import AbstractGeometrySystem
+    from pancad.abstract import AbstractGeometrySystem, AbstractGeometry
     from pancad.utils.pancad_types import SpaceVector, Space3DVector
+
+    # Constraints in a system defined here by listing the SketchConstraint and geometry indices.
+    ConstraintDef = tuple[SC, tuple[int, ...]]
+    SystemTestPair = tuple[ThreeDSketchSystem, ThreeDSketchSystem]
+    PlaneInputs = tuple[Space3DVector, Space3DVector]
+    LineInputs = tuple[Space3DVector, Space3DVector]
 
 SolveTestPair = tuple[ThreeDSketchSystem, ThreeDSketchSystem]
 """Systems to compare. The first is the test system and the second is the goal system."""
+
+def _generate_system(geo: list[AbstractGeometry],
+                     cons_def: list[ConstraintDef]) -> ThreeDSketchSystem:
+    """Generates a new 3D geometry system."""
+    constraints = []
+    for sketch_con, indices in cons_def:
+        constraints.append(make_constraint(sketch_con, *[geo[i] for i in indices]))
+    return ThreeDSketchSystem(geo, constraints)
+
+def _perpendicular_planes(pln1: PlaneInputs, pln2: PlaneInputs,
+                          exppln: PlaneInputs, fix_pt: Space3DVector) -> SystemTestPair:
+    """Generates a system of 1 fixed plane, 1 fixed point, and a plane that is perpendicular to
+    the fixed plane as well as coincident to the fixed point.
+
+    :param pln1: Movable plane's point and normal vectors.
+    :param pln2: Fixed plane's point and normal vectors.
+    :param exppln: Expected result plane's point and normal vectors.
+    :param fix_pt: Fixed point position vector.
+    """
+    cons = [
+        (SC.PERPENDICULAR, (0, 1)),
+        (SC.COINCIDENT, (0, 2)),
+        (SC.UNIQUE, (0,)),
+        (SC.FIXED, (1,)),
+        (SC.FIXED, (2,)),
+    ]
+    initial = _generate_system([Plane(*pln1), Plane(*pln2), Point(fix_pt)], cons)
+    expected = _generate_system([Plane(*exppln), Plane(*pln2), Point(fix_pt)], cons)
+    return initial, expected
 
 def _sys_line_co_2_fixed_pts(ref_pt: Space3DVector, direction: SpaceVector,
                              p1: SpaceVector, p2: SpaceVector) -> ThreeDSketchSystem:
@@ -318,7 +353,7 @@ class TestResiduals:
     def test_perpendicular(self, v1: SpaceVector, v2: SpaceVector, expected: float) -> None:
         """Test for calculating the residual of two vectors that must be perpendicular."""
         assert pcres.perpendicular(np.array(v1, dtype=np.float64),
-                                  np.array(v2, dtype=np.float64)) == expected
+                                   np.array(v2, dtype=np.float64)) == expected
 
     @pytest.mark.parametrize(
         "vector, atol, expected",
@@ -364,6 +399,38 @@ class TestResiduals:
         exp = np.array(expected)
         atol = np.float64(atol)
         nptest.assert_array_equal(pcres.unique_vector(v, zero_atol=atol), exp)
+
+    @pytest.mark.parametrize(
+        "plane, point, distance, expected",
+        [
+            pytest.param(((0,0,0),(0,0,1)), (0,0,0), 0, 0, id="000-0d-xy"),
+            pytest.param(((0,0,0),(0,0,1)), (0,0,1), 1, 0, id="00n1-1d-xy"),
+            pytest.param(((0,0,0),(0,0,1)), (0,0,-1), -1, 0, id="00n1-n1d-xy"),
+        ]
+    )
+    def test_point_plane_distance(self, plane: PlaneInputs, point: Space3DVector, distance: float,
+                                  expected: float) -> None:
+        """Test for calculating the distance residual of a point-plane distance constraint."""
+        pln_pt, normal = map(np.array, plane)
+        result = pcres.point_plane_distance(pln_pt, normal, np.array(point), np.float64(distance))
+        assert result == expected
+
+    @pytest.mark.parametrize(
+        "plane, line, distance, expected",
+        [
+            pytest.param(((0,0,0),(0,0,1)), ((0,0,0),(1,0,0)), 0, 0, id="xy-0d-xline"),
+            pytest.param(((0,0,0),(0,0,1)), ((0,0,1),(1,0,0)), 0, 1, id="xy-0d-1r-001L100"),
+            pytest.param(((0,0,0),(0,0,1)), ((0,0,-1),(1,0,0)), 0, -1, id="xy-0d-n1r-00n1L100"),
+        ]
+    )
+    def test_plane_line_distance(self, plane: PlaneInputs, line: LineInputs,
+                                 distance: float, expected: float) -> None:
+        """Test for calculating the distance residual of a line/axis-plane distance constraint."""
+        pln_pt, normal = map(np.array, plane)
+        line_pt, direction = map(np.array, line)
+        result = pcres.plane_line_distance(pln_pt, normal, line_pt, direction,
+                                           np.float64(distance))
+        assert result == expected
 
     @pytest.mark.parametrize(
         "point1, normal1, point2, normal2, distance, expected",
@@ -460,3 +527,76 @@ class TestResidualHelpers:
     def test_get_unique_vector(self, vector: tuple[float, ...], expected: tuple[float, ...]):
         result = pcres.get_unique_vector(np.array(vector))
         np.testing.assert_array_equal(result, expected)
+
+    @pytest.mark.parametrize(
+        "plane, point, expected",
+        [
+            ### Moving Point around the XY plane.
+            # Origin Point on the XY plane.
+            pytest.param(((0,0,0), (0,0,1)), (0,0,0), 0, id="000-to-xy"),
+            # Point 1 unit above the XY plane.
+            pytest.param(((0,0,0), (0,0,1)), (0,0,1), 1, id="001-to-xy"),
+            # Point 5 units above the XY plane.
+            pytest.param(((0,0,0), (0,0,1)), (0,0,10), 10, id="005-to-xy"),
+            # Point 1 unit below the XY plane.
+            pytest.param(((0,0,0), (0,0,1)), (0,0,-1), -1, id="00n1-to-xy"),
+            # Point at 5,5,0 on the XY plane.
+            pytest.param(((0,0,0), (0,0,1)), (5,5,0), 0, id="550-to-xy"),
+            # Point at 5,5,5 above the XY plane.
+            pytest.param(((0,0,0), (0,0,1)), (5,5,5), 5, id="555-to-xy"),
+            # Point at 5,5,-5 below the XY plane.
+            pytest.param(((0,0,0), (0,0,1)), (5,5,-5), -5, id="55n5-to-xy"),
+
+            ### Moving Point around an XY plane with its normal vector reversed.
+            # Point 1 unit above the plane.
+            pytest.param(((0,0,0), (0,0,-1)), (0,0,1), -1, id="001-to-000pt-00n1norm"),
+            # Point 1 unit below the plane.
+            pytest.param(((0,0,0), (0,0,-1)), (0,0,-1), 1, id="00n1-to-000pt-00n1norm"),
+
+            ### Moving Point around a plane positioned 1 unit above the XY plane.
+            # Point on the plane.
+            pytest.param(((0,0,1), (0,0,1)), (0,0,1), 0, id="001-to-001pt-001norm"),
+            # Point 1 unit above the plane.
+            pytest.param(((0,0,1), (0,0,1)), (0,0,2), 1, id="002-to-001pt-001norm"),
+            # Point 1 unit below the plane.
+            pytest.param(((0,0,1), (0,0,1)), (0,0,0), -1, id="000-to-001pt-001norm"),
+
+            ### Moving point around a 0,0,5 normal vector XY plane. Should have no effect.
+            # Point on the XY Plane.
+            pytest.param(((0,0,0), (0,0,5)), (0,0,0), 0, id="000-to-5normxy"),
+            # Point 1 unit above the XY plane.
+            pytest.param(((0,0,0), (0,0,5)), (0,0,1), 1, id="001-to-5normxy"),
+            # Point 5 units above the XY plane.
+            pytest.param(((0,0,0), (0,0,5)), (0,0,10), 10, id="005-to-5normxy"),
+            # Point 1 unit below the XY plane.
+            pytest.param(((0,0,0), (0,0,5)), (0,0,-1), -1, id="00n1-to-5normxy"),
+
+            ### Moving point around a 0,0,-5 normal vector XY plane. Should have no effect.
+            # Point 1 unit above the plane.
+            pytest.param(((0,0,0), (0,0,-5)), (0,0,1), -1, id="001-to-000pt-00n5norm"),
+            # Point 1 unit below the plane.
+            pytest.param(((0,0,0), (0,0,-5)), (0,0,-1), 1, id="00n1-to-000pt-00n5norm"),
+
+            ### Moving point around a 0,0,0 point, 1,1,1 normal vector plane.
+            # Origin Point on the plane.
+            pytest.param(((0,0,0), (1,1,1)), (0,0,0), 0, id="000-to-000pt-111norm"),
+            # Point 1,1,1 above the plane.
+            pytest.param(((0,0,0), (1,1,1)), (1,1,1), np.linalg.norm((1,1,1)),
+                         id="000-to-111pt-111norm"),
+            # Point -1,-1,-1 below the plane.
+            pytest.param(((0,0,0), (1,1,1)), (-1,-1,-1), -np.linalg.norm((1,1,1)),
+                         id="000-to-n1n1n1pt-111norm"),
+
+        ]
+    )
+    def test_get_plane_to_point_distance(self, plane: PlaneInputs, point: Space3DVector,
+                                         expected: float | np.float64) -> None:
+        """Test that plane to point distance is the correct magnitude and sign."""
+        plane_point, normal = map(np.array, plane)
+        result = pcres.get_plane_to_point_distance(plane_point, normal, np.array(point))
+        assert result == pytest.approx(expected)
+
+    def test_get_plane_to_point_distance_zero_normal_exc(self) -> None:
+        plane_point, normal, point = map(np.array, ((1,1,1), (0,0,0), (1,1,1)))
+        with pytest.raises(ValueError):
+            pcres.get_plane_to_point_distance(plane_point, normal, point)

--- a/tests/test_utils/test_system_solver.py
+++ b/tests/test_utils/test_system_solver.py
@@ -62,6 +62,24 @@ def _perpendicular_planes(pln1: PlaneInputs, pln2: PlaneInputs,
     expected = _generate_system([Plane(*exppln), Plane(*pln2), Point(fix_pt)], cons)
     return initial, expected
 
+def _coincident_planes(plane_1: PlaneInputs, plane_2: PlaneInputs,
+                       expected_plane: PlaneInputs) -> SystemTestPair:
+    """Generates a pair of systems for 1 fixed plane and a plane that is coincident to the fixed
+    plane.
+
+    :param plane_1: Movable plane's point and normal vectors.
+    :param plane_2: Fixed plane's point and normal vectors.
+    :param expected_plane: Expected result plane's point and normal vectors.
+    """
+    cons = [
+        (SC.COINCIDENT, (0, 1)),
+        (SC.UNIQUE, (0,)),
+        (SC.FIXED, (1,)),
+    ]
+    initial = _generate_system([Plane(*plane_1), Plane(*plane_2)], cons)
+    expected = _generate_system([Plane(*expected_plane), Plane(*plane_2)], cons)
+    return initial, expected
+
 def _sys_line_co_2_fixed_pts(ref_pt: Space3DVector, direction: SpaceVector,
                              p1: SpaceVector, p2: SpaceVector) -> ThreeDSketchSystem:
     """Generates an system of a line and two fixed points."""
@@ -191,6 +209,10 @@ def _2_planes_distance(fix_pln_vecs: tuple[Space3DVector, Space3DVector],
         pytest.param(*_2_planes_distance(((0,0,0), (0,0,1)), ((0,0,0), (1,0,0)), 10),
                      id="plane-dist-xy-yz-10",
                      marks=pytest.mark.xfail(reason="Starting from perp planes not yet defined")),
+        pytest.param(
+            *_coincident_planes(((0,0,1), (0,0,1)), ((0,0,0), (0,0,1)), ((0,0,0), (0,0,1))),
+            id="planes-coincident-xyp1z-to-xy"
+        ),
     ]
 )
 def test_solve_system(initial: AbstractGeometrySystem, expected: AbstractGeometrySystem,
@@ -504,7 +526,7 @@ class TestResidualHelpers:
         [
             # 0D
             pytest.param(tuple(), tuple(), id="0d"),
-            
+
             # 1D
             pytest.param((0,), (0,), id="zero_vector_1d"),
             pytest.param((1,), (1,), id="1_1d"),


### PR DESCRIPTION
# Summary

Added constraint solving for constraining lines coincident to planes. Tested the new functionality by constraining a line to two intersecting fixed planes. Closes #270.

# Changes

1. Consolidated plane to point distance solving into one function to reduce the chance of solving it in two different ways
2. Added implied constraint system for cases where a constraint between two geometries imply another constraint. In this case it's that in order to define a distance between a line and a plane they have to also be parallel.
3. Moving the residual function map into solver_residuals.py
4. Added new parameter sorting system to ensure that the ConstraintEquations get their parameters ordered per their geometry types. There had been a bug that meant the line parameters could be accidentally switched with the plane parameters.
5. Removed the last of the direct warnings imports and replaced them with the numpy.errstate context manager.