### PR TITLE
Unique List and Abstract Static Type Checking

### DIFF
--- a/src/pancad/abstract.py
+++ b/src/pancad/abstract.py
@@ -252,6 +252,10 @@ class AbstractGeometrySystem(AbstractGeometry):
     def constraints(self) -> Sequence[AbstractConstraint]:
         """The constraints on the elements inside the system's context."""
 
+    @abstractmethod
+    def __contains__(self, item: Any) -> bool:
+        """Checks whether the item is inside the geometry system."""
+
 class AbstractFeatureSystem(AbstractGeometrySystem):
     """A type of geometry system defining the interfaces provided by systems of topologically
     ordered pancad Feature elements. Should be used when the ordering of the elements inside the

--- a/src/pancad/abstract.py
+++ b/src/pancad/abstract.py
@@ -11,7 +11,7 @@ from pancad.constants import ConstraintReference
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
-    from typing import Self, Optional
+    from typing import Self, Optional, Any
     from uuid import UUID
 
     from pancad.constants import SketchConstraint

--- a/src/pancad/abstract.py
+++ b/src/pancad/abstract.py
@@ -11,7 +11,7 @@ from pancad.constants import ConstraintReference
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
-    from typing import Self
+    from typing import Self, Optional
     from uuid import UUID
 
     from pancad.constants import SketchConstraint
@@ -21,8 +21,11 @@ class PancadThing(ABC):
     """An abstract class defining the properties and methods that all pancad
     elements, constraints, or whatever must have with no exceptions.
     """
-    def __init__(self, system: PancadThing=None):
-        self.system = system
+    def __init__(self, system: Optional[AbstractGeometrySystem]=None):
+        self._system: Optional[AbstractGeometrySystem] = None
+        if system is not None:
+            self.system = system
+        self._uid: UUID | str
 
     STR_VERBOSE = False
     """A flag allowing pancad objects to print detailed strings and reprs."""
@@ -37,21 +40,22 @@ class PancadThing(ABC):
         """
         return self._uid
     @uid.setter
-    def uid(self, value: str | UUID | None) -> None:
+    def uid(self, value: Optional[str | UUID]) -> None:
         if value is None:
             self._uid = uuid4()
         else:
             self._uid = value
 
     @property
-    def system(self) -> PancadThing | None:
+    def system(self) -> Optional[AbstractGeometrySystem]:
         """The system that defines the object's location and dependencies. Some
         objects like files representing parts or assemblies can exist by
         themselves, which is indicated by those objects' system being None.
         """
         return self._system
+
     @system.setter
-    def system(self, value: PancadThing | None) -> None:
+    def system(self, value: AbstractGeometrySystem) -> None:
         self._system = value
 
     @abstractmethod
@@ -75,7 +79,7 @@ class PancadThing(ABC):
 class AbstractFeature(PancadThing):
     """A class defining the interfaces provided by pancad Feature elements."""
 
-    def __init__(self, system: PancadThing=None, name: str="") -> None:
+    def __init__(self, system: Optional[AbstractGeometrySystem]=None, name: str="") -> None:
         super().__init__(system)
         self._name = name
 
@@ -87,17 +91,20 @@ class AbstractFeature(PancadThing):
         """
         return self._name
     @name.setter
-    def name(self, value: str) -> str | None:
+    def name(self, value: str) -> None:
         self._name = value
 
-    def get_dependencies(self) -> list[AbstractFeature]:
+    def get_dependencies(self) -> list[PancadThing]:
         """Returns the feature's external feature dependencies."""
-        if self.system is not None and self is not self.system:
-            dependencies = set()
-            dependencies.add(self.system.feature)
+        if self.system is None:
+            return []
+        if self.system.feature is None:
+            return [self.system]
+        dependencies = set()
+        dependencies.add(self.system.feature)
+        if isinstance(self.system, AbstractFeatureSystem):
             dependencies.update(self.system.get_topo_dependencies(self))
-            return list(dependencies)
-        return []
+        return list(dependencies)
 
     @abstractmethod
     def is_equal(self, other: AbstractFeature) -> bool:
@@ -111,20 +118,23 @@ class AbstractGeometry(PancadThing):
     """A class defining interfaces common to all pancad Geometry Elements."""
     def __init__(self, references: dict[ConstraintReference, AbstractGeometry],
                  *,
-                 system: AbstractGeometrySystem=None,
-                 feature: AbstractFeature=None,
+                 system: Optional[AbstractGeometrySystem]=None,
+                 feature: Optional[AbstractFeature]=None,
                  ) -> None:
+        self._feature: Optional[AbstractFeature] = None
         self._references = references
         super().__init__(system)
-        self.feature = feature
+        if feature is not None:
+            self.feature = feature
         for _, child in self.children.items():
             if child.uid != self.uid:
                 child.parent = self
 
     @property
-    def feature(self) -> AbstractFeature:
+    def feature(self) -> Optional[AbstractFeature]:
         """The feature that owns this geometry element."""
         return self._feature
+
     @feature.setter
     def feature(self, value: AbstractFeature) -> None:
         self._feature = value
@@ -133,17 +143,18 @@ class AbstractGeometry(PancadThing):
                 child.feature = value
 
     @property
-    def system(self) -> PancadThing | None:
+    def system(self) -> Optional[AbstractGeometrySystem]:
         return self._system
+
     @system.setter
-    def system(self, value: PancadThing | None) -> None:
+    def system(self, value: Optional[AbstractGeometrySystem]) -> None:
         self._system = value
         for _, child in self.children.items():
             if child.uid != self.uid:
                 child.system = value
 
     @property
-    def parent(self) -> AbstractGeometry | None:
+    def parent(self) -> Optional[AbstractGeometry]:
         """The parent of the geometry.
 
         Example: A circle center point's parent would be the circle, but if the
@@ -182,9 +193,9 @@ class AbstractGeometry(PancadThing):
                 for reference in self.get_all_references()}
 
     # Public Methods
-    def get_dependencies(self) -> list[AbstractFeature]:
+    def get_dependencies(self) -> list[PancadThing]:
         """Returns the features that this geometry element depends on."""
-        dependencies = []
+        dependencies: list[PancadThing] = []
         if self.feature:
             dependencies.append(self.feature)
         return dependencies
@@ -193,7 +204,7 @@ class AbstractGeometry(PancadThing):
         """Returns the subgeometry associated with the reference."""
         return self._references[reference]
 
-    def get_all_references(self) -> tuple[ConstraintReference]:
+    def get_all_references(self) -> list[ConstraintReference]:
         """Returns the constraint references available for the geometry."""
         return list(self._references.keys())
 
@@ -213,6 +224,7 @@ class AbstractGeometry(PancadThing):
         """
 
     # Python Dunders #
+    @abstractmethod
     def __len__(self) -> int:
         """Implements the Python len() function to return whether the geometry
         is 2D or 3D.
@@ -226,7 +238,7 @@ class AbstractGeometrySystem(AbstractGeometry):
     """
 
     @abstractmethod
-    def get_dependencies(self) -> list[AbstractFeature]:
+    def get_dependencies(self) -> list[PancadThing]:
         """Must return the features that the system depends on."""
 
     @abstractmethod
@@ -240,31 +252,52 @@ class AbstractGeometrySystem(AbstractGeometry):
     def constraints(self) -> Sequence[AbstractConstraint]:
         """The constraints on the elements inside the system's context."""
 
+class AbstractFeatureSystem(AbstractGeometrySystem):
+    """A type of geometry system defining the interfaces provided by systems of topologically
+    ordered pancad Feature elements. Should be used when the ordering of the elements inside the
+    system matters, like a sketch needing to come before an extrude.
+    """
+
+    @abstractmethod
+    def get_topo_index(self, value: AbstractFeature | AbstractConstraint) -> int:
+        """Returns the index of the value that defines its place in the system's
+        topological ordering.
+        """
+
+    @abstractmethod
+    def get_topo_dependencies(self, value: AbstractFeature | AbstractConstraint
+                              ) -> list[AbstractFeature]:
+        """Returns the dependencies of the value from its topological ordering
+        For example, a sketch inside the system would be dependent on the
+        features involved in constraining its pose.
+        """
+
 class AbstractConstraint(PancadThing):
     """A class defining the interfaces provided by all pancad Constraint
     Elements.
     """
     def __init__(self,
-                 system: AbstractGeometrySystem=None) -> None:
+                 system: Optional[AbstractGeometrySystem]=None) -> None:
         super().__init__(system)
-        if self.system:
+        self._feature: Optional[AbstractFeature] = None
+        if self.system and self.system.feature:
             self.feature = self.system.feature
-        else:
-            self.feature = None
 
     # Properties
     @property
-    def feature(self) -> AbstractFeature | None:
+    def feature(self) -> Optional[AbstractFeature]:
         """The feature that owns this constraint."""
         return self._feature
+
     @feature.setter
-    def feature(self, value: AbstractFeature):
+    def feature(self, value: AbstractFeature) -> None:
         self._feature = value
 
     @property
     def _geometry(self) -> list[AbstractGeometry]:
         """The geometry being constrained"""
         return self.__geometry
+
     @_geometry.setter
     def _geometry(self, values: Sequence[AbstractGeometry]) -> None:
         self.__geometry = list(values)
@@ -272,19 +305,21 @@ class AbstractConstraint(PancadThing):
     @property
     def _pairs(self) -> list[tuple[AbstractGeometry, ConstraintReference]]:
         return self.__pairs
+
     @_pairs.setter
     def _pairs(self, value: list[tuple[AbstractGeometry,
                                        ConstraintReference]]) -> None:
         self.__pairs = value
 
     @property
-    def system(self) -> AbstractGeometrySystem | None:
+    def system(self) -> Optional[AbstractGeometrySystem]:
         """The system the constraint is in. This defaults to None unless set by
         a higher level context like a SketchGeometrySystem object.
         """
         if not hasattr(self, "_system"):
             return None
         return self._system
+
     @system.setter
     def system(self, value: AbstractGeometrySystem) -> None:
         self._system = value
@@ -296,7 +331,7 @@ class AbstractConstraint(PancadThing):
         """Returns the SketchConstraint enum value for the constraint type."""
 
     # Public Methods
-    def get_dependencies(self) -> list[AbstractFeature]:
+    def get_dependencies(self) -> list[PancadThing]:
         """Returns the features that this constraint depends on."""
         geometry_deps = []
         for geometry in self.get_parents():
@@ -304,8 +339,10 @@ class AbstractConstraint(PancadThing):
                 raise ValueError(f"Geometry '{geometry}' cannot be constrained"
                                  " if its feature is None")
             geometry_deps.append(geometry.feature)
-        geometry_deps = [geometry.feature for geometry in self.get_parents()]
-        return list(set([self.system.feature] + geometry_deps))
+        geometry_deps = [geometry.feature for geometry in self.get_parents() if geometry.feature]
+        if self.system and self.system.feature:
+            geometry_deps.append(self.system.feature)
+        return list(set(geometry_deps))
 
     def get_parents(self) -> list[AbstractGeometry]:
         """Returns highest geometry scope being constrained for each geometry.
@@ -329,11 +366,11 @@ class AbstractConstraint(PancadThing):
         """
         return self._geometry
 
-    def get_references(self) -> tuple[ConstraintReference]:
+    def get_references(self) -> list[ConstraintReference]:
         """Returns a tuple of the constrained geometrys' ConstraintReferences in
         the same order as the tuple returned by :meth:`get_constrained`.
         """
-        return tuple(geometry.self_reference for geometry in self._geometry)
+        return [geometry.self_reference for geometry in self._geometry]
 
     # Dunders
     def __repr__(self) -> str:
@@ -351,7 +388,7 @@ class AbstractConstraint(PancadThing):
             geometry_strings.append(
                 repr(geometry).replace("<", "").replace(">", "")
             )
-            geometry_strings[-1] += reference.name
+            geometry_strings[-1] += str(reference.name)
         strings.append(",".join(geometry_strings))
         strings.append(">")
         return "".join(strings)

--- a/src/pancad/geometry/system.py
+++ b/src/pancad/geometry/system.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from collections.abc import Sequence
 from typing import TYPE_CHECKING
 
-from pancad.abstract import AbstractGeometrySystem
+from pancad.abstract import AbstractGeometrySystem, AbstractFeatureSystem
 from pancad.constants import ConstraintReference
 from pancad.exceptions import SketchGeometryHasConstraintsError
 from pancad.geometry.coordinate_system import CoordinateSystem
@@ -26,7 +26,7 @@ if TYPE_CHECKING:
     from pancad.geometry.plane import Plane
     from pancad.geometry.point import Point
 
-class FeatureSystem(AbstractGeometrySystem):
+class FeatureSystem(AbstractFeatureSystem):
     """A class managing the relationships between features, their internal
     geometry, and constraints between them.
 

--- a/src/pancad/geometry/unique_lists.py
+++ b/src/pancad/geometry/unique_lists.py
@@ -22,10 +22,9 @@ if TYPE_CHECKING:
 
 
 class UniqueCADList(MutableSequence, metaclass=ABCMeta):
-    """A class managing a mutable list of CAD elements (geometry, constraints,
-    features).
+    """A class managing a mutable list of CAD geometry and constraints inside a system.
 
-    :param parent: The object containing this list.
+    :param parent: The geometry system containing this list.
     :param values: elements to initialize the list with.
     :raises DupeUidError: When trying to add multiple of elements with
         the same uid to the list.
@@ -299,17 +298,32 @@ class FeatureConstraintList(UniqueCADList):
         previous_value.system = None
         previous_value.feature = None
 
-class FeatureGeometryList(UniqueCADList):
-    """A class managing the list of geometry that a feature owns. Feature
-    geometry includes any geometry that would need to be deleted if the
-    feature was deleted.
+class FeatureGeometryList(MutableSequence):
+    """A class managing the list of geometry that a feature owns. Feature geometry includes any
+    geometry that would need to be deleted if the feature was deleted. This list differs from a
+    geometry or constraint list because it is directly owned by a feature rather than existing
+    inside a system.
     """
     __type_name = "Feature Geometry"
 
-    def __init__(self, parent: FeatureSystem,
-                 values: Sequence[AbstractGeometry]) -> None:
-        # TODO: Change Feature container to set the parent to the system rather than the feature.
-        super().__init__(parent, values)
+    def __init__(self, parent: AbstractFeature,
+                 values: Optional[Sequence[AbstractGeometry]]=None) -> None:
+        self._parent = parent
+        self._values: list[AbstractGeometry] = []
+        if values is not None:
+            self.extend(values)
+
+    def get_by_uid(self, uid: str | UUID) -> PancadThing:
+        """Returns a geometry element from the list with the matching uid.
+
+        :raises LookupError: When no matching uid is found.
+        """
+        try:
+            return next(value for value in self if value.uid == uid)
+        except StopIteration as exc:
+            raise LookupError(
+                f"No {self._type_name} with uid '{uid}' found."
+            ) from exc
 
     def insert(self, index: int, value: AbstractGeometry) -> None:
         """Inserts the object into the list and assigns its feature to the
@@ -317,16 +331,36 @@ class FeatureGeometryList(UniqueCADList):
 
         :raises DupeUidError: When a duped uid value is added to the list.
         """
-
         self._raise_if_duped_uid(value)
         self._values.insert(index, value)
         self._assign_feature(value)
+
+    @property
+    def _type_name(self) -> str:
+        """Name used in error messages for this list."""
+        return self.__type_name
+
+    def _raise_if_duped_uid(self, value: PancadThing) -> None:
+        """Raises a DupeUidError if the geometry's uid is already in the list. Used when trying to
+        add geometry to the list.
+        """
+        if value in self:
+            msg = f"{self._type_name} {value} uid: {value.uid} already in list."
+            raise DupeUidError(msg)
 
     def _assign_feature(self, value: AbstractGeometry) -> None:
         if value.feature is not None:
             raise ValueError(f"{self._type_name} '{value}' is already"
                              f" in another feature: '{value.feature}'")
         value.feature = self._parent
+
+    @overload
+    def __getitem__(self, index: int) -> AbstractGeometry: ...
+    @overload
+    def __getitem__(self, index: slice[int | None, int | None, int | None]
+                    ) -> list[AbstractGeometry]: ...
+    def __getitem__(self, index):
+        return self._values[index]
 
     @overload
     def __delitem__(self, index: int) -> None: ...
@@ -337,7 +371,7 @@ class FeatureGeometryList(UniqueCADList):
         if isinstance(index, slice):
             raise NotImplementedError("Cannot use slices with setitem yet, see #281")
         previous_value = self._values[index]
-        super().__delitem__(index)
+        del self._values[index]
         # Remove the feature from exiting geometry
         previous_value.feature = None
 
@@ -353,11 +387,18 @@ class FeatureGeometryList(UniqueCADList):
         previous_value = self._values[index]
         if self[index].uid != value.uid:
             self._raise_if_duped_uid(value)
-        self._raise_if_has_dependents(self[index])
         self._values[index] = value
         self._assign_feature(value)
         # Remove the feature from exiting geometry
         previous_value.feature = None
+
+    def __contains__(self, value: Any) -> bool:
+        if not isinstance(value, PancadThing):
+            return False
+        return any(value.uid == element.uid for element in self._values)
+
+    def __len__(self) -> int:
+        return len(self._values)
 
 class UniqueSketchElementList(UniqueCADList, metaclass=ABCMeta):
     """A class managing the interfaces for CAD sketch lists."""

--- a/src/pancad/geometry/unique_lists.py
+++ b/src/pancad/geometry/unique_lists.py
@@ -1,9 +1,11 @@
 """A module defining the lists of unique CAD elements used by features and geometry."""
 from __future__ import annotations
 
+from abc import ABCMeta
 from collections.abc import MutableSequence
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, overload
 
+from pancad.abstract import PancadThing
 from pancad.exceptions import (
     DupeUidError,
     HasDependentsError,
@@ -11,28 +13,29 @@ from pancad.exceptions import (
 )
 
 if TYPE_CHECKING:
-    from typing import Sequence, Optional
+    from collections.abc import Iterable
+    from typing import Sequence, Optional, Any
     from uuid import UUID
 
     from pancad.abstract import (
-        AbstractFeature, AbstractGeometry, AbstractConstraint, PancadThing
+        AbstractFeature, AbstractGeometry, AbstractConstraint, AbstractGeometrySystem
     )
     from pancad.geometry.system import SketchGeometrySystem, FeatureSystem
 
 
-class UniqueCADList(MutableSequence):
-    """A class managing a mutable list of CAD elements (geometry, constraints, 
+class UniqueCADList(MutableSequence, metaclass=ABCMeta):
+    """A class managing a mutable list of CAD elements (geometry, constraints,
     features).
 
     :param parent: The object containing this list.
     :param values: elements to initialize the list with.
-    :raises DupeUidError: When trying to add multiple of elements with 
+    :raises DupeUidError: When trying to add multiple of elements with
         the same uid to the list.
     """
     __type_name = "PancadThing"
 
     def __init__(self,
-                 parent: PancadThing,
+                 parent: AbstractGeometrySystem,
                  values: Optional[Sequence[PancadThing]]=None) -> None:
         self._parent = parent
         self._values: list[PancadThing] = []
@@ -58,23 +61,15 @@ class UniqueCADList(MutableSequence):
                 f"No {self._type_name} with uid '{uid}' found."
             ) from exc
 
-    def insert(self, index: int, value: PancadThing) -> None:
-        """Inserts the pancad element into the list.
-
-        :raises DupeUidError: When a duped uid value is added to the list.
-        """
-        self._raise_if_duped_uid(value)
-        self._values.insert(index, value)
-
     def get_contents(self) -> list[PancadThing]:
-        """Returns the full list of contents, including any items in specialized 
+        """Returns the full list of contents, including any items in specialized
         indices.
         """
         return self._values
 
     # Private Methods
     def _raise_if_duped_uid(self, value: PancadThing) -> None:
-        """Raises a DupeUidError if the geometry's uid is already in the 
+        """Raises a DupeUidError if the geometry's uid is already in the
         list. Used when trying to add geometry to the list.
         """
         if value in self:
@@ -82,7 +77,7 @@ class UniqueCADList(MutableSequence):
             raise DupeUidError(msg)
 
     def _raise_if_has_dependents(self, value: PancadThing) -> None:
-        """Raises a HasDependentsError if geometry still has 
+        """Raises a HasDependentsError if geometry still has
         constraints. Used when trying to delete geometry from list.
         """
         if dependents := self._parent.get_dependents(value):
@@ -90,14 +85,25 @@ class UniqueCADList(MutableSequence):
             raise HasDependentsError(msg)
 
     # Dunders
-    def __getitem__(self, index: int) -> PancadThing:
+    @overload
+    def __getitem__(self, index: int) -> PancadThing: ...
+    @overload
+    def __getitem__(self, index: slice[int | None, int | None, int | None]
+                    ) -> list[PancadThing]: ...
+    def __getitem__(self, index):
         return self._values[index]
 
-    def __setitem__(self, index: int, value: PancadThing) -> None:
+    @overload
+    def __setitem__(self, index: int, value: PancadThing) -> None: ...
+    # TODO: Implement Second __setitem__ overload
+    @overload
+    def __setitem__(self, index: slice[int | None, int | None, int | None],
+                    value: Iterable[PancadThing]) -> None: ...
+    def __setitem__(self, index, value):
         """Sets the index to the value.
 
         :raises DupeUidError: When a duped uid value is added to the list.
-        :raises HasDependentsError: When trying to replace an element that still 
+        :raises HasDependentsError: When trying to replace an element that still
             has dependents.
         """
         if self[index].uid != value.uid:
@@ -105,9 +111,14 @@ class UniqueCADList(MutableSequence):
         self._raise_if_has_dependents(self[index])
         self._values[index] = value
 
-    def __delitem__(self, index: int) -> None:
+    # TODO: Implement second __delitem__ overload
+    @overload
+    def __delitem__(self, index: int) -> None: ...
+    @overload
+    def __delitem__(self, index: slice[int | None, int | None, int | None]) -> None: ...
+    def __delitem__(self, index):
         """Deletes the value from the list after checking deletion validity.
-        
+
         :raises HasDependentsError: Raised if the feature still has dependents.
         """
         self._raise_if_has_dependents(self[index])
@@ -116,7 +127,9 @@ class UniqueCADList(MutableSequence):
     def __len__(self) -> int:
         return len(self._values)
 
-    def __contains__(self, value: PancadThing) -> bool:
+    def __contains__(self, value: Any) -> bool:
+        if not isinstance(value, PancadThing):
+            return False
         return any(value.uid == element.uid for element in self.get_contents())
 
     def __repr__(self) -> str:
@@ -127,8 +140,8 @@ class UniqueCADList(MutableSequence):
 
 
 class SystemFeatureList(UniqueCADList):
-    """A class managing a mutable list of CAD features inside of a 
-    FeatureSystem. The list's parent does not contribute to the lists's 
+    """A class managing a mutable list of CAD features inside of a
+    FeatureSystem. The list's parent does not contribute to the lists's
     length, but is accessible at index -1.
 
     :param parent: The system containing this list.
@@ -142,17 +155,20 @@ class SystemFeatureList(UniqueCADList):
         super().__init__(parent, values)
 
     # Public Methods
-    def index(self, value: AbstractFeature, start: int=0, stop: int=None) -> int:
+    def index(self, value: AbstractFeature, start: int=0, stop: Optional[int]=None) -> int:
         if value is self._parent.feature:
             return -1
+        if stop is None:
+            return super().index(value, start)
         return super().index(value, start, stop)
 
     def insert(self, index: int, value: AbstractFeature) -> None:
-        """Inserts the object into the list and assigns its system to the 
+        """Inserts the object into the list and assigns its system to the
         list's parent.
         """
         self._raise_if_missing_dependencies(value)
-        super().insert(index, value)
+        self._raise_if_duped_uid(value)
+        self._values.insert(index, value)
         self._assign_system(value)
 
     def get_by_name(self, name: str) -> AbstractFeature:
@@ -178,7 +194,7 @@ class SystemFeatureList(UniqueCADList):
                 if feature not in self._parent]
 
     def _raise_if_missing_dependencies(self, value: AbstractFeature):
-        """Raises a MissingCADDependencyError when not all of a constraint's 
+        """Raises a MissingCADDependencyError when not all of a constraint's
         dependencies are in the list's system.
         """
         if missing := self.missing_dependencies(value):
@@ -209,7 +225,7 @@ class SystemFeatureList(UniqueCADList):
         previous_value.system = None
 
 class FeatureConstraintList(UniqueCADList):
-    """A class managing the mutable list of constraints between features and 
+    """A class managing the mutable list of constraints between features and
     their dependencies.
     """
     __type_name = "Constraint"
@@ -223,11 +239,16 @@ class FeatureConstraintList(UniqueCADList):
 
     # Public Methods
     def insert(self, index: int, value: AbstractConstraint) -> None:
-        """Inserts the object into the list and assigns its system to the 
+        """Inserts the object into the list and assigns its system to the
         list's parent.
+
+        :raises DupeUidError: When a duped uid value is added to the list.
+        :raises MissingCADDependencyError: When not all constraint
+            dependencies are in the constraint lists's parent.
         """
         self._raise_if_missing_dependencies(value)
-        super().insert(index, value)
+        self._raise_if_duped_uid(value)
+        self._values.insert(index, value)
         self._assign_system(value)
 
     def missing_dependencies(self,
@@ -250,7 +271,7 @@ class FeatureConstraintList(UniqueCADList):
         value.feature = self._parent.feature
 
     def _raise_if_missing_dependencies(self, value: AbstractConstraint):
-        """Raises a MissingCADDependencyError when not all of a constraint's 
+        """Raises a MissingCADDependencyError when not all of a constraint's
         dependencies are in the list's system.
         """
         if missing := self.missing_dependencies(value):
@@ -259,7 +280,7 @@ class FeatureConstraintList(UniqueCADList):
 
     # Dunders
     def __setitem__(self, index: int, value: AbstractConstraint) -> None:
-        """Replaces object in list and removes the old object's system and 
+        """Replaces object in list and removes the old object's system and
         feature.
         """
         previous_value = self._values[index] # -1 is not allowed here
@@ -271,8 +292,8 @@ class FeatureConstraintList(UniqueCADList):
         previous_value.feature = None
 
 class FeatureGeometryList(UniqueCADList):
-    """A class managing the list of geometry that a feature owns. Feature 
-    geometry includes any geometry that would need to be deleted if the 
+    """A class managing the list of geometry that a feature owns. Feature
+    geometry includes any geometry that would need to be deleted if the
     feature was deleted.
     """
     __type_name = "Feature Geometry"
@@ -282,10 +303,14 @@ class FeatureGeometryList(UniqueCADList):
         super().__init__(parent, values)
 
     def insert(self, index: int, value: AbstractGeometry) -> None:
-        """Inserts the object into the list and assigns its feature to the 
+        """Inserts the object into the list and assigns its feature to the
         list's parent.
+
+        :raises DupeUidError: When a duped uid value is added to the list.
         """
-        super().insert(index, value)
+
+        self._raise_if_duped_uid(value)
+        self._values.insert(index, value)
         self._assign_feature(value)
 
     def _assign_feature(self, value: AbstractGeometry) -> None:
@@ -310,20 +335,13 @@ class FeatureGeometryList(UniqueCADList):
         # Remove the feature from exiting geometry
         previous_value.feature = None
 
-class UniqueSketchElementList(UniqueCADList):
+class UniqueSketchElementList(UniqueCADList, metaclass=ABCMeta):
     """A class managing the interfaces for CAD sketch lists."""
-    def insert(self, index: int,
-               value: AbstractConstraint | AbstractGeometry) -> None:
-        """Inserts the object into the list and assigns its system to the 
-        list's parent.
-        """
-        super().insert(index, value)
-        self._assign_system(value)
 
     # Private Methods
     def _assign_system(self,
                        value: AbstractConstraint | AbstractGeometry) -> None:
-        """Assigns the system of the sketch element to the list's parent and the 
+        """Assigns the system of the sketch element to the list's parent and the
         feature to the parent's feature.
         """
         if value.system is not None:
@@ -353,12 +371,12 @@ class UniqueSketchElementList(UniqueCADList):
 
 
 class SketchGeometryList(UniqueSketchElementList):
-    """A class managing a mutable list of geometry. The list's parent does not 
+    """A class managing a mutable list of geometry. The list's parent does not
     contribute to the lists's length, but is accessible at index -1.
 
     :param parent: The SketchGeometrySystem that contains this list.
     :param values: Geometry to initialize the list with.
-    :raises DupeUidError: When trying to add multiple geometries with the same 
+    :raises DupeUidError: When trying to add multiple geometries with the same
         uid to the list.
     """
     __type_name = "Geometry"
@@ -371,6 +389,16 @@ class SketchGeometryList(UniqueSketchElementList):
     def get_contents(self) -> list[AbstractGeometry]:
         return [self._parent] + super().get_contents()
 
+    def insert(self, index: int, value: AbstractGeometry) -> None:
+        """Inserts the object into the list and assigns its system to the
+        list's parent.
+
+        :raises DupeUidError: When a duped uid value is added to the list.
+        """
+        self._raise_if_duped_uid(value)
+        self._values.insert(index, value)
+        self._assign_system(value)
+
     def __getitem__(self, index: int) -> AbstractGeometry:
         if index == -1:
             return self._parent
@@ -378,12 +406,12 @@ class SketchGeometryList(UniqueSketchElementList):
 
 
 class SketchConstraintList(UniqueSketchElementList):
-    """A class managing a mutable list of sketch constraints and their 
+    """A class managing a mutable list of sketch constraints and their
     dependencies.
 
     :param parent: The SketchGeometrySystem that contains this list.
     :param values: Constraints to initialize the list with.
-    :raises DupeUidError: When trying to add multiple constraints with the same 
+    :raises DupeUidError: When trying to add multiple constraints with the same
         uid to the list.
     """
     __type_name = "Constraint"
@@ -398,12 +426,15 @@ class SketchConstraintList(UniqueSketchElementList):
     # Public Methods
     def insert(self, index: int, value: AbstractConstraint) -> None:
         """Inserts the constraint into the constraint list.
-        
+
         :raises MissingCADDependencyError: When not all constraint
             dependencies are in the constraint lists's associated system.
+        :raises DupeUidError: When a duped uid value is added to the list.
         """
         self._raise_if_missing_dependencies(value)
-        super().insert(index, value)
+        self._raise_if_duped_uid(value)
+        self._values.insert(index, value)
+        self._assign_system(value)
 
     def missing_dependencies(self, value: AbstractConstraint
                              ) -> list[AbstractGeometry]:
@@ -413,7 +444,7 @@ class SketchConstraintList(UniqueSketchElementList):
 
     # Private Methods
     def _raise_if_missing_dependencies(self, value: AbstractConstraint):
-        """Raises a MissingCADDependencyError when not all of a constraint's 
+        """Raises a MissingCADDependencyError when not all of a constraint's
         dependencies are in the list's system.
         """
         if missing := self.missing_dependencies(value):
@@ -422,8 +453,8 @@ class SketchConstraintList(UniqueSketchElementList):
     # Dunders
     def __setitem__(self, index: int, value: AbstractConstraint) -> None:
         """Sets the index to the constraint.
-        
-        :raises MissingCADDependencyError: When not all constraint 
+
+        :raises MissingCADDependencyError: When not all constraint
             dependencies are in the constraint lists's parent.
         """
         self._raise_if_missing_dependencies(value)

--- a/src/pancad/geometry/unique_lists.py
+++ b/src/pancad/geometry/unique_lists.py
@@ -411,12 +411,9 @@ class UniqueSketchElementList(UniqueCADList, metaclass=ABCMeta):
         if value.system is not None:
             raise ValueError(f"{self._type_name} '{value}' is already"
                              f" in another system: '{value.system}'")
-        # TODO: Put geometry systems into features for unit tests
-        # if self._parent.feature is None:
-            # msg = f"This list's parent is not in a feature, cannot assign feature of {value}"
-            # raise RuntimeError(msg)
         value.system = self._parent
-        value.feature = self._parent.feature
+        if self._parent.feature is not None:
+            value.feature = self._parent.feature
 
     # Dunders
     @overload

--- a/src/pancad/geometry/unique_lists.py
+++ b/src/pancad/geometry/unique_lists.py
@@ -5,7 +5,7 @@ from abc import ABCMeta
 from collections.abc import MutableSequence
 from typing import TYPE_CHECKING, overload
 
-from pancad.abstract import PancadThing
+from pancad.abstract import PancadThing, AbstractConstraint
 from pancad.exceptions import (
     DupeUidError,
     HasDependentsError,
@@ -17,9 +17,7 @@ if TYPE_CHECKING:
     from typing import Sequence, Optional, Any
     from uuid import UUID
 
-    from pancad.abstract import (
-        AbstractFeature, AbstractGeometry, AbstractConstraint, AbstractGeometrySystem
-    )
+    from pancad.abstract import AbstractFeature, AbstractGeometry, AbstractGeometrySystem
     from pancad.geometry.system import SketchGeometrySystem, FeatureSystem
 
 
@@ -250,7 +248,7 @@ class FeatureConstraintList(UniqueCADList):
                              value: AbstractConstraint) -> list[AbstractFeature]:
         """Returns missing feature dependencies for a constraint."""
         return [geometry.feature for geometry in value.get_parents()
-                if geometry.feature not in self._parent]
+                if geometry.feature not in self._parent and geometry.feature]
 
     #Private Methods
     def _assign_system(self, value: AbstractConstraint) -> None:
@@ -262,6 +260,9 @@ class FeatureConstraintList(UniqueCADList):
             msg = (f"{self._type_name} '{value}' is already"
                    f" in another feature: '{value.feature}'")
             raise ValueError(msg)
+        if self._parent.feature is None:
+            msg = f"This list's parent is not in a feature, cannot assign the feature of {value}"
+            raise RuntimeError(msg)
         value.system = self._parent
         value.feature = self._parent.feature
 
@@ -302,8 +303,9 @@ class FeatureGeometryList(UniqueCADList):
     """
     __type_name = "Feature Geometry"
 
-    def __init__(self, parent: AbstractFeature,
+    def __init__(self, parent: FeatureSystem,
                  values: Sequence[AbstractGeometry]) -> None:
+        # TODO: Change Feature container to set the parent to the system rather than the feature.
         super().__init__(parent, values)
 
     def insert(self, index: int, value: AbstractGeometry) -> None:
@@ -363,6 +365,10 @@ class UniqueSketchElementList(UniqueCADList, metaclass=ABCMeta):
         if value.system is not None:
             raise ValueError(f"{self._type_name} '{value}' is already"
                              f" in another system: '{value.system}'")
+        # TODO: Put geometry systems into features for unit tests
+        # if self._parent.feature is None:
+            # msg = f"This list's parent is not in a feature, cannot assign feature of {value}"
+            # raise RuntimeError(msg)
         value.system = self._parent
         value.feature = self._parent.feature
 
@@ -393,7 +399,7 @@ class SketchGeometryList(UniqueSketchElementList):
 
     def __init__(self,
                  parent: SketchGeometrySystem,
-                 values: Sequence[AbstractGeometry]=None) -> None:
+                 values: Sequence[AbstractGeometry]) -> None:
         super().__init__(parent, values)
 
     def _get_contents(self) -> list[PancadThing]:
@@ -510,5 +516,7 @@ class SketchConstraintList(UniqueSketchElementList):
     def __len__(self) -> int:
         return len(self._values)
 
-    def __contains__(self, value: AbstractConstraint) -> bool:
-        return any(value.uid == element.uid for element in self)
+    def __contains__(self, value: object) -> bool:
+        if isinstance(value, AbstractConstraint):
+            return any(value.uid == element.uid for element in self)
+        return False

--- a/src/pancad/geometry/unique_lists.py
+++ b/src/pancad/geometry/unique_lists.py
@@ -11,7 +11,7 @@ from pancad.exceptions import (
 )
 
 if TYPE_CHECKING:
-    from typing import Sequence
+    from typing import Sequence, Optional
     from uuid import UUID
 
     from pancad.abstract import (
@@ -33,9 +33,9 @@ class UniqueCADList(MutableSequence):
 
     def __init__(self,
                  parent: PancadThing,
-                 values: Sequence[PancadThing]=None) -> None:
+                 values: Optional[Sequence[PancadThing]]=None) -> None:
         self._parent = parent
-        self._values = []
+        self._values: list[PancadThing] = []
         if values is not None:
             self.extend(values)
 

--- a/src/pancad/geometry/unique_lists.py
+++ b/src/pancad/geometry/unique_lists.py
@@ -61,7 +61,7 @@ class UniqueCADList(MutableSequence, metaclass=ABCMeta):
                 f"No {self._type_name} with uid '{uid}' found."
             ) from exc
 
-    def get_contents(self) -> list[PancadThing]:
+    def _get_contents(self) -> list[PancadThing]:
         """Returns the full list of contents, including any items in specialized
         indices.
         """
@@ -130,7 +130,7 @@ class UniqueCADList(MutableSequence, metaclass=ABCMeta):
     def __contains__(self, value: Any) -> bool:
         if not isinstance(value, PancadThing):
             return False
-        return any(value.uid == element.uid for element in self.get_contents())
+        return any(value.uid == element.uid for element in self._get_contents())
 
     def __repr__(self) -> str:
         return str(self)
@@ -182,10 +182,10 @@ class SystemFeatureList(UniqueCADList):
             msg = f"No {self._type_name} with name '{name}' found."
             raise LookupError(msg) from exc
 
-    def get_contents(self) -> list[AbstractFeature]:
+    def _get_contents(self) -> list[PancadThing]:
         if self._parent.feature is not None:
-            return [self._parent.feature] + super().get_contents()
-        return super().get_contents()
+            return [self._parent.feature] + super()._get_contents()
+        return super()._get_contents()
 
     def missing_dependencies(self,
                              value: AbstractFeature) -> list[AbstractFeature]:
@@ -386,8 +386,8 @@ class SketchGeometryList(UniqueSketchElementList):
                  values: Sequence[AbstractGeometry]=None) -> None:
         super().__init__(parent, values)
 
-    def get_contents(self) -> list[AbstractGeometry]:
-        return [self._parent] + super().get_contents()
+    def _get_contents(self) -> list[PancadThing]:
+        return [self._parent] + super()._get_contents()
 
     def insert(self, index: int, value: AbstractGeometry) -> None:
         """Inserts the object into the list and assigns its system to the

--- a/src/pancad/geometry/unique_lists.py
+++ b/src/pancad/geometry/unique_lists.py
@@ -86,30 +86,12 @@ class UniqueCADList(MutableSequence, metaclass=ABCMeta):
 
     # Dunders
     @overload
-    def __getitem__(self, index: int) -> PancadThing: ...
+    def __getitem__(self, index: int) -> Any: ...
     @overload
     def __getitem__(self, index: slice[int | None, int | None, int | None]
-                    ) -> list[PancadThing]: ...
+                    ) -> list[Any]: ...
     def __getitem__(self, index):
         return self._values[index]
-
-    @overload
-    def __setitem__(self, index: int, value: PancadThing) -> None: ...
-    # TODO: Implement Second __setitem__ overload
-    @overload
-    def __setitem__(self, index: slice[int | None, int | None, int | None],
-                    value: Iterable[PancadThing]) -> None: ...
-    def __setitem__(self, index, value):
-        """Sets the index to the value.
-
-        :raises DupeUidError: When a duped uid value is added to the list.
-        :raises HasDependentsError: When trying to replace an element that still
-            has dependents.
-        """
-        if self[index].uid != value.uid:
-            self._raise_if_duped_uid(value)
-        self._raise_if_has_dependents(self[index])
-        self._values[index] = value
 
     # TODO: Implement second __delitem__ overload
     @overload
@@ -188,7 +170,7 @@ class SystemFeatureList(UniqueCADList):
         return super()._get_contents()
 
     def missing_dependencies(self,
-                             value: AbstractFeature) -> list[AbstractFeature]:
+                             value: AbstractFeature) -> list[PancadThing]:
         """Returns missing feature dependencies for a feature."""
         return [feature for feature in value.get_dependencies()
                 if feature not in self._parent]
@@ -209,17 +191,30 @@ class SystemFeatureList(UniqueCADList):
         value.system = self._parent
 
     # Dunders
-    def __getitem__(self, index: int) -> AbstractFeature:
+    @overload
+    def __getitem__(self, index: int) -> AbstractFeature: ...
+    @overload
+    def __getitem__(self, index: slice[int | None, int | None, int | None]
+                    ) -> list[AbstractFeature]: ...
+    def __getitem__(self, index):
         if index == -1:
             return self._parent.feature
         return super().__getitem__(index)
 
-    def __setitem__(self, index: int,
-                    value: AbstractConstraint | AbstractGeometry) -> None:
+    @overload
+    def __setitem__(self, index: int, value: AbstractFeature) -> None: ...
+    # TODO: Implement Second __setitem__ overload
+    @overload
+    def __setitem__(self, index: slice[int | None, int | None, int | None],
+                    value: Iterable[AbstractFeature]) -> None: ...
+    def __setitem__(self, index, value):
         """Replaces object in list and removes the old object's system."""
         self._raise_if_missing_dependencies(value)
         previous_value = self._values[index] # -1 is not allowed here
-        super().__setitem__(index, value)
+        if self[index].uid != value.uid:
+            self._raise_if_duped_uid(value)
+        self._raise_if_has_dependents(self[index])
+        self._values[index] = value
         self._assign_system(value)
         # Remove the system from exiting element
         previous_value.system = None
@@ -279,13 +274,22 @@ class FeatureConstraintList(UniqueCADList):
             raise MissingCADDependencyError(msg)
 
     # Dunders
-    def __setitem__(self, index: int, value: AbstractConstraint) -> None:
+    @overload
+    def __setitem__(self, index: int, value: AbstractConstraint) -> None: ...
+    # TODO: Implement Second __setitem__ overload
+    @overload
+    def __setitem__(self, index: slice[int | None, int | None, int | None],
+                    value: Iterable[AbstractConstraint]) -> None: ...
+    def __setitem__(self, index, value):
         """Replaces object in list and removes the old object's system and
         feature.
         """
         previous_value = self._values[index] # -1 is not allowed here
         self._raise_if_missing_dependencies(value)
-        super().__setitem__(index, value)
+        if self[index].uid != value.uid:
+            self._raise_if_duped_uid(value)
+        self._raise_if_has_dependents(self[index])
+        self._values[index] = value
         self._assign_system(value)
         # Remove the system from exiting element
         previous_value.system = None
@@ -319,18 +323,31 @@ class FeatureGeometryList(UniqueCADList):
                              f" in another feature: '{value.feature}'")
         value.feature = self._parent
 
-    def __delitem__(self, index: int) -> None:
+    # TODO: Implement second __delitem__ overload
+    @overload
+    def __delitem__(self, index: int) -> None: ...
+    @overload
+    def __delitem__(self, index: slice[int | None, int | None, int | None]) -> None: ...
+    def __delitem__(self, index):
         """Deletes object from list and removes its feature."""
         previous_value = self._values[index]
         super().__delitem__(index)
         # Remove the feature from exiting geometry
         previous_value.feature = None
 
-    def __setitem__(self, index: int,
-                    value: AbstractConstraint | AbstractGeometry) -> None:
+    @overload
+    def __setitem__(self, index: int, value: AbstractGeometry) -> None: ...
+    # TODO: Implement Second __setitem__ overload
+    @overload
+    def __setitem__(self, index: slice[int | None, int | None, int | None],
+                    value: Iterable[AbstractGeometry]) -> None: ...
+    def __setitem__(self, index, value):
         """Replaces object in list and removes the old object's feature."""
         previous_value = self._values[index]
-        super().__setitem__(index, value)
+        if self[index].uid != value.uid:
+            self._raise_if_duped_uid(value)
+        self._raise_if_has_dependents(self[index])
+        self._values[index] = value
         self._assign_feature(value)
         # Remove the feature from exiting geometry
         previous_value.feature = None
@@ -339,8 +356,7 @@ class UniqueSketchElementList(UniqueCADList, metaclass=ABCMeta):
     """A class managing the interfaces for CAD sketch lists."""
 
     # Private Methods
-    def _assign_system(self,
-                       value: AbstractConstraint | AbstractGeometry) -> None:
+    def _assign_system(self, value: AbstractConstraint | AbstractGeometry) -> None:
         """Assigns the system of the sketch element to the list's parent and the
         feature to the parent's feature.
         """
@@ -351,24 +367,18 @@ class UniqueSketchElementList(UniqueCADList, metaclass=ABCMeta):
         value.feature = self._parent.feature
 
     # Dunders
-    def __delitem__(self, index: int) -> None:
+    # TODO: Implement second __delitem__ overload
+    @overload
+    def __delitem__(self, index: int) -> None: ...
+    @overload
+    def __delitem__(self, index: slice[int | None, int | None, int | None]) -> None: ...
+    def __delitem__(self, index):
         """Deletes object from list and removes its system."""
         previous_value = self._values[index] # -1 is not allowed here
         super().__delitem__(index)
         # Remove the system from exiting element
         previous_value.system = None
         previous_value.feature = None
-
-    def __setitem__(self, index: int,
-                    value: AbstractConstraint | AbstractGeometry) -> None:
-        """Replaces object in list and removes the old object's system."""
-        previous_value = self._values[index] # -1 is not allowed here
-        super().__setitem__(index, value)
-        self._assign_system(value)
-        # Remove the system from exiting element
-        previous_value.system = None
-        previous_value.feature = None
-
 
 class SketchGeometryList(UniqueSketchElementList):
     """A class managing a mutable list of geometry. The list's parent does not
@@ -399,10 +409,33 @@ class SketchGeometryList(UniqueSketchElementList):
         self._values.insert(index, value)
         self._assign_system(value)
 
-    def __getitem__(self, index: int) -> AbstractGeometry:
+    @overload
+    def __getitem__(self, index: int) -> AbstractGeometry: ...
+    @overload
+    def __getitem__(self, index: slice[int | None, int | None, int | None]
+                    ) -> list[AbstractGeometry]: ...
+    def __getitem__(self, index):
         if index == -1:
             return self._parent
         return super().__getitem__(index)
+
+    @overload
+    def __setitem__(self, index: int, value: AbstractGeometry) -> None: ...
+    # TODO: Implement Second __setitem__ overload
+    @overload
+    def __setitem__(self, index: slice[int | None, int | None, int | None],
+                    value: Iterable[AbstractGeometry]) -> None: ...
+    def __setitem__(self, index, value):
+        """Replaces object in list and removes the old object's system."""
+        previous_value = self._values[index] # -1 is not allowed here
+        if self[index].uid != value.uid:
+            self._raise_if_duped_uid(value)
+        self._raise_if_has_dependents(self[index])
+        self._values[index] = value
+        self._assign_system(value)
+        # Remove the system from exiting element
+        previous_value.system = None
+        previous_value.feature = None
 
 
 class SketchConstraintList(UniqueSketchElementList):
@@ -451,14 +484,28 @@ class SketchConstraintList(UniqueSketchElementList):
             raise MissingCADDependencyError(f"'{value}' missing: {missing}")
 
     # Dunders
-    def __setitem__(self, index: int, value: AbstractConstraint) -> None:
+    @overload
+    def __setitem__(self, index: int, value: AbstractConstraint) -> None: ...
+    # TODO: Implement Second __setitem__ overload
+    @overload
+    def __setitem__(self, index: slice[int | None, int | None, int | None],
+                    value: Iterable[AbstractConstraint]) -> None: ...
+    def __setitem__(self, index, value) -> None:
         """Sets the index to the constraint.
 
         :raises MissingCADDependencyError: When not all constraint
             dependencies are in the constraint lists's parent.
         """
         self._raise_if_missing_dependencies(value)
-        super().__setitem__(index, value)
+        previous_value = self._values[index] # -1 is not allowed here
+        if self[index].uid != value.uid:
+            self._raise_if_duped_uid(value)
+        self._raise_if_has_dependents(self[index])
+        self._values[index] = value
+        self._assign_system(value)
+        # Remove the system from exiting element
+        previous_value.system = None
+        previous_value.feature = None
 
     def __len__(self) -> int:
         return len(self._values)

--- a/src/pancad/geometry/unique_lists.py
+++ b/src/pancad/geometry/unique_lists.py
@@ -91,7 +91,6 @@ class UniqueCADList(MutableSequence, metaclass=ABCMeta):
     def __getitem__(self, index):
         return self._values[index]
 
-    # TODO: Implement second __delitem__ overload
     @overload
     def __delitem__(self, index: int) -> None: ...
     @overload
@@ -101,6 +100,8 @@ class UniqueCADList(MutableSequence, metaclass=ABCMeta):
 
         :raises HasDependentsError: Raised if the feature still has dependents.
         """
+        if isinstance(index, slice):
+            raise NotImplementedError("Cannot use slices with delitem yet, see #281")
         self._raise_if_has_dependents(self[index])
         del self._values[index]
 
@@ -201,12 +202,13 @@ class SystemFeatureList(UniqueCADList):
 
     @overload
     def __setitem__(self, index: int, value: AbstractFeature) -> None: ...
-    # TODO: Implement Second __setitem__ overload
     @overload
     def __setitem__(self, index: slice[int | None, int | None, int | None],
                     value: Iterable[AbstractFeature]) -> None: ...
     def __setitem__(self, index, value):
         """Replaces object in list and removes the old object's system."""
+        if isinstance(index, slice):
+            raise NotImplementedError("Cannot use slices with setitem yet, see #281")
         self._raise_if_missing_dependencies(value)
         previous_value = self._values[index] # -1 is not allowed here
         if self[index].uid != value.uid:
@@ -277,7 +279,6 @@ class FeatureConstraintList(UniqueCADList):
     # Dunders
     @overload
     def __setitem__(self, index: int, value: AbstractConstraint) -> None: ...
-    # TODO: Implement Second __setitem__ overload
     @overload
     def __setitem__(self, index: slice[int | None, int | None, int | None],
                     value: Iterable[AbstractConstraint]) -> None: ...
@@ -285,6 +286,8 @@ class FeatureConstraintList(UniqueCADList):
         """Replaces object in list and removes the old object's system and
         feature.
         """
+        if isinstance(index, slice):
+            raise NotImplementedError("Cannot use slices with setitem yet, see #281")
         previous_value = self._values[index] # -1 is not allowed here
         self._raise_if_missing_dependencies(value)
         if self[index].uid != value.uid:
@@ -325,13 +328,14 @@ class FeatureGeometryList(UniqueCADList):
                              f" in another feature: '{value.feature}'")
         value.feature = self._parent
 
-    # TODO: Implement second __delitem__ overload
     @overload
     def __delitem__(self, index: int) -> None: ...
     @overload
     def __delitem__(self, index: slice[int | None, int | None, int | None]) -> None: ...
     def __delitem__(self, index):
         """Deletes object from list and removes its feature."""
+        if isinstance(index, slice):
+            raise NotImplementedError("Cannot use slices with setitem yet, see #281")
         previous_value = self._values[index]
         super().__delitem__(index)
         # Remove the feature from exiting geometry
@@ -339,12 +343,13 @@ class FeatureGeometryList(UniqueCADList):
 
     @overload
     def __setitem__(self, index: int, value: AbstractGeometry) -> None: ...
-    # TODO: Implement Second __setitem__ overload
     @overload
     def __setitem__(self, index: slice[int | None, int | None, int | None],
                     value: Iterable[AbstractGeometry]) -> None: ...
     def __setitem__(self, index, value):
         """Replaces object in list and removes the old object's feature."""
+        if isinstance(index, slice):
+            raise NotImplementedError("Cannot use slices with setitem yet, see #281")
         previous_value = self._values[index]
         if self[index].uid != value.uid:
             self._raise_if_duped_uid(value)
@@ -373,13 +378,14 @@ class UniqueSketchElementList(UniqueCADList, metaclass=ABCMeta):
         value.feature = self._parent.feature
 
     # Dunders
-    # TODO: Implement second __delitem__ overload
     @overload
     def __delitem__(self, index: int) -> None: ...
     @overload
     def __delitem__(self, index: slice[int | None, int | None, int | None]) -> None: ...
     def __delitem__(self, index):
         """Deletes object from list and removes its system."""
+        if isinstance(index, slice):
+            raise NotImplementedError("Cannot use slices with delitem yet, see #281")
         previous_value = self._values[index] # -1 is not allowed here
         super().__delitem__(index)
         # Remove the system from exiting element
@@ -427,12 +433,13 @@ class SketchGeometryList(UniqueSketchElementList):
 
     @overload
     def __setitem__(self, index: int, value: AbstractGeometry) -> None: ...
-    # TODO: Implement Second __setitem__ overload
     @overload
     def __setitem__(self, index: slice[int | None, int | None, int | None],
                     value: Iterable[AbstractGeometry]) -> None: ...
     def __setitem__(self, index, value):
         """Replaces object in list and removes the old object's system."""
+        if isinstance(index, slice):
+            raise NotImplementedError("Cannot use slices with setitem yet, see #281")
         previous_value = self._values[index] # -1 is not allowed here
         if self[index].uid != value.uid:
             self._raise_if_duped_uid(value)
@@ -492,7 +499,6 @@ class SketchConstraintList(UniqueSketchElementList):
     # Dunders
     @overload
     def __setitem__(self, index: int, value: AbstractConstraint) -> None: ...
-    # TODO: Implement Second __setitem__ overload
     @overload
     def __setitem__(self, index: slice[int | None, int | None, int | None],
                     value: Iterable[AbstractConstraint]) -> None: ...
@@ -502,6 +508,8 @@ class SketchConstraintList(UniqueSketchElementList):
         :raises MissingCADDependencyError: When not all constraint
             dependencies are in the constraint lists's parent.
         """
+        if isinstance(index, slice):
+            raise NotImplementedError("Cannot use slices with setitem yet, see #281")
         self._raise_if_missing_dependencies(value)
         previous_value = self._values[index] # -1 is not allowed here
         if self[index].uid != value.uid:

--- a/tests/test_geometry/test_feature_system.py
+++ b/tests/test_geometry/test_feature_system.py
@@ -49,13 +49,13 @@ def test_add_extrude(init_system, iso_sketch, iso_extrude):
     init_system.features.append(iso_extrude)
     print("\nDirect Dependents")
     pp({feature: init_system.get_direct_dependents(feature)
-        for feature in init_system.features.get_contents()})
+        for feature in init_system.features})
     print("\nTopo Dependents")
     pp({feature: init_system.get_dependents(feature)
-         for feature in init_system.features.get_contents()})
+         for feature in init_system.features})
     print("\nDependencies")
     pp({feature: feature.get_dependencies()
-        for feature in init_system.features.get_contents()})
+        for feature in init_system.features})
 
 def test_add_constraint_without_sketch(init_system, iso_sketch):
     constraint = AlignAxes(init_system.coordinate_system,


### PR DESCRIPTION
# Summary

Refactored abstract.py and unique_list.py to pass static type checking. Closes #279.

# Changes

1. Added optional to all args that can be None
2. Split AbstractFeatureSystem off of AbstractGeometrySystem since it needs topological checking as well
3. Moved most dunder functionality for UniqueCADList down to the more specific lists to avoid violating Liskov principle checking. That enables them to return values specific to their more specialized types like geometry, constraints, features.
4. Made FeatureGeometryList its own MutableSequence instead of specializing it from UniqueCADList since it's owned by a feature and not a geometry system.
5. Made get_contents private since it's only used for containment checking on UniqueCADList. That let it return only PancadThings and not confuse users expecting it to return the specialized list type.