### PR TITLE
Added Perpendicular Plane Constraints

### DIFF
--- a/src/pancad/utils/solver_residuals.py
+++ b/src/pancad/utils/solver_residuals.py
@@ -189,17 +189,40 @@ def equal_vector(v1: npt.NDArray, v2: npt.NDArray) -> npt.NDArray:
     """
     return v1 - v2
 
-def perpendicular(v1: npt.NDArray, v2: npt.NDArray) -> np.float64:
-    """Calculates how close two vectors are to being perpendicular to each other."""
-    n1, n2 = map(np.linalg.norm, (v1, v2))
+def perpendicular(vector_1: npt.NDArray[np.float64],
+                  vector_2: npt.NDArray[np.float64]) -> np.float64:
+    """Calculates how close the second vector is to being on the plane created by the first vector
+    and the origin for the 3D case and just the dot product for the 2D case. Performing a dot
+    product on the vectors squares the values.
+
+    :param vector_1: A 2D or 3D vector.
+    :param vector_2: Another 2D or 3D vector that is the same length as vector_1.
+    :returns: When 3D, the signed distance from the tip of the normalized vector_2 to the virtual
+        plane created by vector_1 and the origin point. When 2D, the value of the vector dot
+        product divided by the two vector norms multiplied together.
+    :raises ValueError: When provided a zero vector or differing length vectors.
+    """
+    if any(len(v) == 2 for v in (vector_1, vector_2)):
+        norm_1, norm_2 = map(np.linalg.norm, (vector_1, vector_2))
+        try:
+            with np.errstate(divide="raise", invalid="raise"):
+                return np.dot(vector_1, vector_2) / (norm_1 * norm_2)
+        except FloatingPointError as exc:
+            msg = f"Cannot normalize, one of the vectors a zero vector: {vector_1}, {vector_2}"
+            raise ValueError(msg) from exc
+        except ValueError as exc:
+            if len(vector_1) != len(vector_2):
+                exc.add_note(f"Expected both vectors to be 2D, got: {vector_1}, {vector_2}")
+            raise
     try:
         with np.errstate(divide="raise", invalid="raise"):
-            # Normalize to reduce round-off by making sure vectors are the same magnitude.
-            # nv1, nv2 = map(lambda v: v / np.linalg.norm(v), (v1, v2))
-            return np.dot(v1, v2) / (n1 * n2)
+            # Normalize the second vector to make perpendicularity independent of vector length.
+            unit_vector_2 = vector_2 / np.linalg.norm(vector_2)
     except FloatingPointError as exc:
-        msg = f"Cannot normalize, one of the vectors is likely a zero vector: {v1}, {v2}"
+        msg = f"Cannot normalize vector 2, likely a zero vector: {vector_2}"
         raise ValueError(msg) from exc
+    return point_plane_coincident(np.array([0,0,0], dtype=np.float64), vector_1, unit_vector_2)
+
 
 def point_line_distance(line_pt: npt.NDArray, direction: npt.NDArray,
                         pt: npt.NDArray, distance: np.float64) -> np.float64:

--- a/src/pancad/utils/solvers.py
+++ b/src/pancad/utils/solvers.py
@@ -256,6 +256,11 @@ class SystemSolver:
     """The absolute tolerance to pass the solver by default. Scipy defaults to
     1.49012e-8 (2^-26), which is the square root of the numpy.float64 eps.
     """
+    iter_per_input = 400
+    """The default maximum number of iterations per input variable. The maximum number of
+    iterations will be (iter_per_input)*(N+1) where N is the number of elements in the initial
+    input vector x0.
+    """
 
     def __init__(self, system: AbstractGeometrySystem) -> None:
         self._system = system
@@ -322,7 +327,10 @@ class SystemSolver:
         if "tol" not in kwargs:
             kwargs["tol"] = self.absolute_tol
         if "options" not in kwargs:
-            kwargs["options"] = {"ftol": np.finfo(np.float64).eps,}
+            kwargs["options"] = {
+                "ftol": np.finfo(np.float64).eps,
+                "maxiter": self.iter_per_input * (len(self.get_initial()) + 1),
+            }
         func = self.fun
         if fun_wrap is not None:
             func = fun_wrap(func)
@@ -588,6 +596,7 @@ class SystemSolver:
         vector_name_map = {
             Point: [CVN.LOCATION],
             Axis: [CVN.REF_POINT, CVN.DIRECTION],
+            Line: [CVN.REF_POINT, CVN.DIRECTION],
             Plane: [CVN.REF_POINT, CVN.NORMAL],
         }
         try:

--- a/tests/test_utils/test_system_solver.py
+++ b/tests/test_utils/test_system_solver.py
@@ -41,15 +41,17 @@ def _generate_system(geo: list[AbstractGeometry],
         constraints.append(make_constraint(sketch_con, *[geo[i] for i in indices]))
     return ThreeDSketchSystem(geo, constraints)
 
-def _perpendicular_planes(pln1: PlaneInputs, pln2: PlaneInputs,
-                          exppln: PlaneInputs, fix_pt: Space3DVector) -> SystemTestPair:
-    """Generates a system of 1 fixed plane, 1 fixed point, and a plane that is perpendicular to
-    the fixed plane as well as coincident to the fixed point.
+def _perpendicular_planes(plane: PlaneInputs, fixed_plane: PlaneInputs, fixed_line: LineInputs,
+                          expected_plane: PlaneInputs) -> SystemTestPair:
+    """Generates a system of 1 movable plane, 1 fixed plane, and 1 fixed line already coincident
+    to the fixed plane. The movable plane is coincident with the fixed line and perpendicular to
+    the fixed plane. The movable plane's normal vector is constrained unique to guarantee only one
+    solution is possible.
 
-    :param pln1: Movable plane's point and normal vectors.
-    :param pln2: Fixed plane's point and normal vectors.
-    :param exppln: Expected result plane's point and normal vectors.
-    :param fix_pt: Fixed point position vector.
+    :param plane: Movable plane's point and normal vectors.
+    :param fixed_plane: Fixed plane's point and normal vectors.
+    :param fixed_line: Fixed line's reference point and direction vectors.
+    :param expected_plane: Expected result plane's point and normal vectors.
     """
     cons = [
         (SC.PERPENDICULAR, (0, 1)),
@@ -58,8 +60,11 @@ def _perpendicular_planes(pln1: PlaneInputs, pln2: PlaneInputs,
         (SC.FIXED, (1,)),
         (SC.FIXED, (2,)),
     ]
-    initial = _generate_system([Plane(*pln1), Plane(*pln2), Point(fix_pt)], cons)
-    expected = _generate_system([Plane(*exppln), Plane(*pln2), Point(fix_pt)], cons)
+    fixed_line = Line(Point(fixed_line[0]), fixed_line[1])
+    initial = _generate_system(
+        [Plane(*plane), Plane(*fixed_plane), fixed_line.copy()], cons)
+    expected = _generate_system([Plane(*expected_plane), Plane(*fixed_plane), fixed_line.copy()],
+                                cons)
     return initial, expected
 
 def _plane_intersection_line(line: LineInputs, plane_1: PlaneInputs, plane_2: PlaneInputs,
@@ -302,6 +307,30 @@ def _2_planes_distance(fix_pln_vecs: tuple[Space3DVector, Space3DVector],
             ),
             id="line-coincident-xz-and-yz-planes"
         ),
+
+        ### Plane-Plane Perpendicular Tests
+        # plane starting at origin and normal pointing to (1,1,1) constrained perpendicular to the
+        # xy plane and coincident with a line on the X axis.
+        pytest.param(
+            *_perpendicular_planes(
+                ((0,0,0), (1,1,1)), # Initial Movable Plane
+                ((0,0,0), (0,0,1)), # Fixed Plane: XY Plane
+                ((0,0,0), (1,0,0)), # Fixed Line: X Axis Line
+                ((0,0,0), (0,1,0)), # Expected Plane: XZ Plane
+            ),
+            id="000-111pln-perp-xypln-coin-xline"
+        ),
+        # Plane starting at (1,1,1) and normal pointing to (1,1,1) constrained perpendicular to
+        # the XY plane and coincident with a line on the X axis.
+        pytest.param(
+            *_perpendicular_planes(
+                ((1,1,1), (1,1,1)), # Initial Movable Plane
+                ((0,0,0), (0,0,1)), # Fixed Plane: XY Plane
+                ((0,0,0), (1,0,0)), # Fixed Line: X Axis Line
+                ((0,0,0), (0,1,0)), # Expected Plane: XZ Plane
+            ),
+            id="111-111pln-perp-xypln-coin-xline"
+        ),
     ]
 )
 def test_solve_system(initial: AbstractGeometrySystem, expected: AbstractGeometrySystem,
@@ -459,6 +488,7 @@ class TestResiduals:
                          id="3d-x-max-and-y-off-to-x-by-eps"),
             # Must use the square root of the max to avoid overflow during normalization squaring
             pytest.param((2,0,0), (EPS_64,2,0), EPS_64/2, id="3d-2x-and-2y-off-to-x-by-eps"),
+            pytest.param((1,0), (0,1), 0, id="2d-x-and-y"),
         ]
     )
     def test_perpendicular(self, v1: SpaceVector, v2: SpaceVector, expected: float) -> None:


### PR DESCRIPTION
# Summary

Modified the way the perpendicular residual calculation is done to calculate the distance the second vector's tip is from the virtual plane created by the first vector. Added ability to modify the max number of solver iterations based on the input count. Added 2 tests for testing that perpendicular works on planes. Closes #251 

# Changes

1. Modified perpendicular residual solving to use the distance between the tip of the second vector and the virtual plane created by the first vector.
2. Also ensured the perpendicular residual still works on 2D vectors by still using the dot product solution when both vectors are 2D
3. Added the ability to modify the maxiter options input into the solver and added a iter_per_input class variable to SystemSolver that sets how many iterations the solver allows per input variable. This is to mitigate the nondeterminism that opened issue #284 
4. Added 2 tests that constrain a plane to be perpendicular to another fixed plane while also being coincident to a fixed line.