### PR TITLE
Point Static Typing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,8 +56,12 @@ extra-dependencies = [
   "mypy>=1.0.0",
 ]
 [tool.hatch.envs.types.scripts]
+# Script to type check a given file
 check = "mypy --install-types --non-interactive {args:.}"
+# Script to strictly type check a given file
 strict = "mypy --install-types --non-interactive --strict {args:.}"
+# Script to strictly type check all the files in the tool.mypy section
+strictdefault = "mypy --install-types --non-interactive --strict"
 
 [[tool.hatch.envs.hatch-test.matrix]]
 python = ["3.11"]
@@ -98,4 +102,12 @@ build = [
 ]
 force-build = [
     "make -B docs",
+]
+
+[tool.mypy]
+files = [
+    "src/pancad/abstract.py",
+    "src/pancad/geometry/point.py",
+    "src/pancad/geometry/unique_lists.py",
+    "src/pancad/utils/trigonometry.py",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ extra-dependencies = [
 ]
 [tool.hatch.envs.types.scripts]
 check = "mypy --install-types --non-interactive {args:.}"
+strict = "mypy --install-types --non-interactive --strict {args:.}"
 
 [[tool.hatch.envs.hatch-test.matrix]]
 python = ["3.11"]

--- a/src/pancad/abstract.py
+++ b/src/pancad/abstract.py
@@ -57,7 +57,7 @@ class PancadThing(ABC):
         return self._system
 
     @system.setter
-    def system(self, value: AbstractGeometrySystem) -> None:
+    def system(self, value: Optional[AbstractGeometrySystem]) -> None:
         self._system = value
 
     @abstractmethod
@@ -138,7 +138,7 @@ class AbstractGeometry(PancadThing):
         return self._feature
 
     @feature.setter
-    def feature(self, value: AbstractFeature) -> None:
+    def feature(self, value: Optional[AbstractFeature]) -> None:
         self._feature = value
         for _, child in self.children.items():
             if child.uid != self.uid:
@@ -296,7 +296,7 @@ class AbstractConstraint(PancadThing):
         return self._feature
 
     @feature.setter
-    def feature(self, value: AbstractFeature) -> None:
+    def feature(self, value: Optional[AbstractFeature]) -> None:
         self._feature = value
 
     @property
@@ -327,7 +327,7 @@ class AbstractConstraint(PancadThing):
         return self._system
 
     @system.setter
-    def system(self, value: AbstractGeometrySystem) -> None:
+    def system(self, value: Optional[AbstractGeometrySystem]) -> None:
         self._system = value
 
     # Abstract Properties

--- a/src/pancad/abstract.py
+++ b/src/pancad/abstract.py
@@ -11,8 +11,10 @@ from pancad.constants import ConstraintReference
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
-    from typing import Self, Optional, Any
+    from typing import Self, Optional, Any, Type, TypeVar
     from uuid import UUID
+
+    T = TypeVar("T")
 
     from pancad.constants import SketchConstraint
 
@@ -210,14 +212,14 @@ class AbstractGeometry(PancadThing):
 
     # Abstract Methods
     @abstractmethod
-    def is_equal(self, other: AbstractGeometry) -> bool:
+    def is_equal(self: T, other: T) -> bool:
         """Returns whether the other geometry is geometrically equal. This is a
         separate check from whether a geometry element is 'python equal' to this
         geometry element since the uids would not be the same.
         """
 
     @abstractmethod
-    def update(self, other: AbstractGeometry) -> Self:
+    def update(self: T, other: T) -> T:
         """Takes geometry of the same type as the calling geometry and updates
         the calling geometry to match the new geometry while maintaining its
         uid. Should return itself afterwards.

--- a/src/pancad/constants/__init__.py
+++ b/src/pancad/constants/__init__.py
@@ -1,5 +1,16 @@
 """This module contains constants used throughout pancad."""
 
+__all__ = [
+    "AngleConvention",
+    "ConfigCategory",
+    "SoftwareName",
+    "ConstraintReference",
+    "FeatureType",
+    "SketchConstraint",
+    "ConstraintVariableName",
+    "ConstraintEquationName",
+]
+
 from ._angle_convention import AngleConvention
 from ._config_cache_category import ConfigCategory
 from ._software_name import SoftwareName

--- a/src/pancad/geometry/point.py
+++ b/src/pancad/geometry/point.py
@@ -5,9 +5,8 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 import math
-from numbers import Real
 from sqlite3 import PrepareProtocol
-from typing import Self, TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 import numpy as np
 
@@ -17,8 +16,14 @@ from pancad.utils import trigonometry as trig
 from pancad.utils.geometry import parse_vector
 
 if TYPE_CHECKING:
+    from typing import Optional, Type, Self
     from uuid import UUID
-    from pancad.utils.pancad_types import PolarVector, SphericalVector
+
+    import numpy.typing as npt
+
+    from pancad.utils.pancad_types import (
+        PolarVector, SphericalVector, SpaceVector, Space2DVector, Space3DVector
+    )
 
 
 class Point(AbstractGeometry):
@@ -33,8 +38,9 @@ class Point(AbstractGeometry):
         arguments or as a single vector.
     :param uid: The unique ID of the point for interoperable CAD identification.
     """
-    def __init__(self, *components: Real | Sequence[Real] | np.ndarray,
-                 uid: str | UUID=None):
+    def __init__(self, *components: float | Sequence[float] | npt.NDArray[np.float64],
+                 uid: Optional[str | UUID]=None):
+        self._cartesian: SpaceVector
         self._iter_index = 0 # Used for __iter__ counting
         self.uid = uid
         self.cartesian = parse_vector(*components)
@@ -42,12 +48,12 @@ class Point(AbstractGeometry):
 
     # Class Methods #
     @classmethod
-    def from_polar(cls, *components: Real | Sequence[Real] | np.ndarray,
-                   uid: str | UUID=None):
+    def from_polar(cls, *components: float | Sequence[float] | npt.NDArray[np.float64],
+                   uid: Optional[str | UUID]=None) -> Point:
         """Initializes a point from polar coordinates.
 
-        :param components: The (Radius (r), Azimuth (phi)) individual Real
-            number arguments or as a single vector. Azimuth must be in radians.
+        :param components: The (Radius (r), Azimuth (phi)) individual number arguments or as a 
+            single vector. Azimuth must be in radians.
         :param uid: The unique ID of the point for interoperable CAD
             identification.
         :raises ValueError: When provided a vector not 2 long.
@@ -58,14 +64,14 @@ class Point(AbstractGeometry):
         return cls(trig.polar_to_cartesian(vector), uid=uid)
 
     @classmethod
-    def from_spherical(cls, *components: Real | Sequence[Real] | np.ndarray,
-                       uid: str | UUID=None):
+    def from_spherical(cls, *components: float | Sequence[float] | npt.NDArray[np.float64],
+                       uid: Optional[str | UUID]=None) -> Point:
         """Initializes a point from spherical coordinates (Radius (r), Azimuth
         (phi), Elevation (theta)). Azimuth and Elevation angles must be in
         radians.
 
         :param components: The (Radius (r), Azimuth (phi), Elevation (theta))
-            individual Real number arguments or as a single vector. Azimuth and
+            individual number arguments or as a single vector. Azimuth and
             Elevation must be in radians.
         :param uid: The unique ID of the point for interoperable CAD
             identification.
@@ -78,53 +84,60 @@ class Point(AbstractGeometry):
 
     # Cartesian Coordinates #
     @property
-    def cartesian(self) -> tuple[Real, Real] | tuple[Real, Real, Real]:
+    def cartesian(self) -> SpaceVector:
         """The cartesian coordinates (x, y) or(x, y, z) of the point.
 
-        :raises ValueError: When provided a tuple not 2 or 3 long.
+        :raises ValueError: When provided a sequence not 2 or 3 long.
         """
         return self._cartesian
 
     @cartesian.setter
-    def cartesian(self, value: Sequence[Real]) -> None:
-        if len(value) not in [2, 3]:
+    def cartesian(self, value: Sequence[float]) -> None:
+        if len(value) == 2:
+            x, y = value
+            self._cartesian = (x, y)
+        elif len(value) == 3:
+            x, y, z = value
+            self._cartesian = (x, y, z)
+        else:
             raise ValueError(f"Expected 2 or 3 long vector, given {len(value)}")
-        self._cartesian = tuple(value)
 
     @property
-    def x(self) -> Real:
+    def x(self) -> float:
         """The point's cartesian x-coordinate."""
         return self.cartesian[0]
 
     @x.setter
-    def x(self, value: Real) -> None:
-        if len(self) == 2:
-            self.cartesian = (value, self.cartesian[1])
+    def x(self, value: float) -> None:
+        if len(self._cartesian) == 2:
+            self.cartesian = (value, self._cartesian[1])
         else:
-            self.cartesian = (value, self.cartesian[1], self.cartesian[2])
+            self.cartesian = (value, self._cartesian[1], self._cartesian[2])
 
     @property
-    def y(self) -> Real:
+    def y(self) -> float:
         """The point's cartesian y-coordinate."""
         return self.cartesian[1]
 
     @y.setter
-    def y(self, value: Real) -> None:
-        if len(self) == 2:
-            self.cartesian = (self.cartesian[0], value)
+    def y(self, value: float) -> None:
+        if len(self._cartesian) == 2:
+            self.cartesian = (self._cartesian[0], value)
         else:
-            self.cartesian = (self.cartesian[0], value, self.cartesian[2])
+            self.cartesian = (self._cartesian[0], value, self._cartesian[2])
 
     @property
-    def z(self) -> Real:
+    def z(self) -> float:
         """The point's cartesian z-coordinate. Turns a 2D point 3D if set.
 
         :raises IndexError: When the getter is called on a 2D point.
         """
-        return self.cartesian[2]
+        if len(self.cartesian) == 3:
+            return self.cartesian[2]
+        raise IndexError("Cannot get the z value of a 2D point")
 
     @z.setter
-    def z(self, value: Real) -> None:
+    def z(self, value: float) -> None:
         self.cartesian = (self.cartesian[0], self.cartesian[1], value)
 
     # Polar/Spherical Coordinates
@@ -135,10 +148,12 @@ class Point(AbstractGeometry):
 
         :raises ValueError: When called if the point is 3D.
         """
-        return trig.cartesian_to_polar(self.cartesian)
+        if len(self.cartesian) == 2:
+            return trig.cartesian_to_polar(self.cartesian)
+        raise ValueError(f"Cannot get the polar coordinates of a {len(self.cartesian)}D Point")
 
     @polar.setter
-    def polar(self, value: tuple[Real, Real]) -> None:
+    def polar(self, value: Space2DVector) -> None:
         self.cartesian = trig.polar_to_cartesian(value)
 
     @property
@@ -148,14 +163,16 @@ class Point(AbstractGeometry):
 
         :raises ValueError: When called if the point is 2D.
         """
-        return trig.cartesian_to_spherical(self.cartesian)
+        if len(self.cartesian) == 3:
+            return trig.cartesian_to_spherical(self.cartesian)
+        raise ValueError(f"Cannot get spherical coordinates of a {len(self.cartesian)}D Point")
 
     @spherical.setter
-    def spherical(self, value: tuple[Real, Real, Real]) -> None:
+    def spherical(self, value: Space3DVector) -> None:
         self.cartesian = trig.spherical_to_cartesian(value)
 
     @property
-    def r(self) -> Real:
+    def r(self) -> float:
         """The polar/spherical radial distance coordinate of the point.
 
         :raises ValueError: If r < 0, r is NaN, r == 0 and phi is NaN, or r != 0
@@ -166,7 +183,7 @@ class Point(AbstractGeometry):
         return self.spherical.r
 
     @r.setter
-    def r(self, value: Real) -> None:
+    def r(self, value: float) -> None:
         if value < 0:
             raise ValueError("r cannot be less than zero")
         if math.isnan(value):
@@ -187,7 +204,7 @@ class Point(AbstractGeometry):
                 raise ValueError("r must be 0 if phi and theta are NaN")
 
     @property
-    def phi(self) -> Real:
+    def phi(self) -> float:
         """The polar/spherical azimuth angle of the point in radians.
 
         :raises ValueError: If phi is NaN and r != 0, r == 0 and phi is not NaN,
@@ -198,7 +215,7 @@ class Point(AbstractGeometry):
         return self.spherical.phi
 
     @phi.setter
-    def phi(self, value: Real) -> None:
+    def phi(self, value: float) -> None:
         if len(self) == 2: # Polar
             if self.polar.r != 0 and math.isnan(value):
                 raise ValueError("phi cannot be NaN if r is non-zero")
@@ -213,7 +230,7 @@ class Point(AbstractGeometry):
             self.spherical = (self.r, value, self.theta)
 
     @property
-    def theta(self) -> Real:
+    def theta(self) -> float:
         """The spherical inclination angle of the point in radians.
 
         :raises ValueError: If phi is NaN and theta is not 0, pi or NaN.
@@ -222,7 +239,7 @@ class Point(AbstractGeometry):
         return self.spherical.theta
 
     @theta.setter
-    def theta(self, value: Real) -> None:
+    def theta(self, value: float) -> None:
         if math.isnan(self.spherical.phi) and value not in [0, math.pi, math.nan]:
             raise ValueError("theta must be NaN, 0, or pi if phi is NaN")
         self.spherical = (self.spherical.r, self.spherical.phi, value)
@@ -232,24 +249,24 @@ class Point(AbstractGeometry):
         """Returns a copy of the Point at the same position, different uid."""
         return Point(self.cartesian)
 
-    def is_equal(self, other: Point) -> Point:
+    def is_equal(self, other: Point) -> bool:
         """Returns whether the other geometry is geometrically equal. This is a
         separate check from whether a geometry element is equal to this
         geometry element since the uids would not be the same.
         """
         return np.allclose(self.cartesian, other.cartesian)
 
-    def phi_degrees(self) -> Real:
+    def phi_degrees(self) -> float:
         """Returns the polar/spherical azimuth angle of the Point in degrees."""
         if len(self) == 2:
             return math.degrees(self.polar.phi)
         return math.degrees(self.spherical.phi)
 
-    def theta_degrees(self) -> Real:
+    def theta_degrees(self) -> float:
         """Returns the spherical inclination angle of the point in degrees."""
         return math.degrees(self.spherical.theta)
 
-    def set_phi_degrees(self, value: Real) -> Self:
+    def set_phi_degrees(self, value: float) -> Self:
         """Sets the polar/spherical azimuth coordinate of the point using a
         value in degrees. Returns the updated point.
         """
@@ -259,7 +276,7 @@ class Point(AbstractGeometry):
             self.spherical = (self.spherical.r, math.radians(value), self.spherical.theta)
         return self
 
-    def set_theta_degrees(self, value: Real) -> Self:
+    def set_theta_degrees(self, value: float) -> Self:
         """Sets the spherical inclination coordinate of the point using a
         value in degrees. Returns the updated point.
         """
@@ -277,7 +294,7 @@ class Point(AbstractGeometry):
         self.cartesian = other.cartesian
         return self
 
-    def vector(self, vertical: bool=True) -> np.ndarray:
+    def vector(self, vertical: bool=True) -> npt.NDArray[np.float64]:
         """Returns a numpy vector of the point's cartesian.
 
         :param vertical: Sets whether to return a vertical vector. Defaults True.
@@ -289,7 +306,7 @@ class Point(AbstractGeometry):
         return array
 
     # Python Dunders #
-    def __add__(self, other) -> tuple[Real]:
+    def __add__(self, other: Point | npt.NDArray[np.float64] | SpaceVector) -> SpaceVector:
         """Returns the addition of two point's cartesian position vectors."""
         if isinstance(other, (np.ndarray, tuple)):
             if len(self) == len(other):
@@ -303,13 +320,13 @@ class Point(AbstractGeometry):
             raise ValueError("Cannot add 2D points to/from 3D points")
         return NotImplemented
 
-    def __conform__(self, protocol: PrepareProtocol):
+    def __conform__(self, protocol: Type[PrepareProtocol]) -> str:
         """Conforms the point's values for storage in sqlite."""
         if protocol is PrepareProtocol:
             return ";".join(map(str, self.cartesian))
         raise TypeError(f"Expected sqlite3.PrepareProtocol, got {protocol}")
 
-    def __sub__(self, other) -> tuple[Real]:
+    def __sub__(self, other: Point | npt.NDArray[np.float64] | SpaceVector) -> SpaceVector:
         """Returns the subtraction of two point's cartesian position vectors as
         a tuple"""
         if isinstance(other, Point):
@@ -325,7 +342,7 @@ class Point(AbstractGeometry):
         """
         return self.copy()
 
-    def __getitem__(self, item: int) -> Real:
+    def __getitem__(self, item: int) -> float:
         """Returns the cartesian coordinates when subscripted. 0 returns x, 1
         returns y, 2 returns z.
         """
@@ -335,7 +352,7 @@ class Point(AbstractGeometry):
         """Returns the dimension of the Point, 2 or 3."""
         return len(self.cartesian)
 
-    def __iter__(self):
+    def __iter__(self) -> Self:
         """Iterator function to allow the point's cartesian position to be
         output when the point is fed to a list or tuple like function.
         """
@@ -363,16 +380,16 @@ class Point(AbstractGeometry):
         return super().__repr__().format(details=f"({point_str})")
 
     # NumPy Dunders #
-    def __array__(self, dtype=None, copy=None) -> np.ndarray:
+    def __array__(self, dtype: None=None, copy: None=None) -> npt.NDArray[np.float64]:
         """Array function to allow the point to be fed into a numpy array
         function and return a horizontal numpy array.
 
-        :raises ValueError: When copy is set to False. copy argument only
-            included for numpy compatibility.
+        :raises TypeError: When copy is set to False. copy argument only included for numpy 
+            compatibility.
         """
         array = np.array(list(self))
         if copy is not None and not copy:
-            raise ValueError("pancad Point cannot return the original")
+            raise TypeError("pancad Point cannot return the original")
         if dtype:
             return array.astype(dtype)
         return array

--- a/src/pancad/geometry/unique_lists.py
+++ b/src/pancad/geometry/unique_lists.py
@@ -3,25 +3,30 @@ from __future__ import annotations
 
 from abc import ABCMeta
 from collections.abc import MutableSequence
-from typing import TYPE_CHECKING, overload
+from typing import TYPE_CHECKING, overload, Generic, TypeVar
 
-from pancad.abstract import PancadThing, AbstractConstraint
+from pancad.abstract import PancadThing, AbstractConstraint, AbstractFeature, AbstractGeometry
 from pancad.exceptions import (
     DupeUidError,
     HasDependentsError,
     MissingCADDependencyError,
 )
 
+T = TypeVar("T", bound=PancadThing)
+GC = TypeVar("GC", bound=AbstractGeometry | AbstractConstraint)
+
 if TYPE_CHECKING:
     from collections.abc import Iterable
-    from typing import Sequence, Optional, Any
+    from typing import Sequence, Optional
     from uuid import UUID
 
-    from pancad.abstract import AbstractFeature, AbstractGeometry, AbstractGeometrySystem
+    from pancad.abstract import AbstractGeometrySystem
     from pancad.geometry.system import SketchGeometrySystem, FeatureSystem
 
+    ListSlice = slice[int | None, int | None, int | None]
 
-class UniqueCADList(MutableSequence, metaclass=ABCMeta):
+
+class UniqueCADList(MutableSequence[T], Generic[T], metaclass=ABCMeta):
     """A class managing a mutable list of CAD geometry and constraints inside a system.
 
     :param parent: The geometry system containing this list.
@@ -33,9 +38,9 @@ class UniqueCADList(MutableSequence, metaclass=ABCMeta):
 
     def __init__(self,
                  parent: AbstractGeometrySystem,
-                 values: Optional[Sequence[PancadThing]]=None) -> None:
+                 values: Optional[Sequence[T]]=None) -> None:
         self._parent = parent
-        self._values: list[PancadThing] = []
+        self._values: list[T] = []
         if values is not None:
             self.extend(values)
 
@@ -46,7 +51,7 @@ class UniqueCADList(MutableSequence, metaclass=ABCMeta):
         return self.__type_name
 
     # Public Methods
-    def get_by_uid(self, uid: str | UUID) -> PancadThing:
+    def get_by_uid(self, uid: str | UUID) -> T:
         """Returns a feature with the matching uid.
 
         :raises LookupError: When no matching uid is found.
@@ -58,14 +63,14 @@ class UniqueCADList(MutableSequence, metaclass=ABCMeta):
                 f"No {self._type_name} with uid '{uid}' found."
             ) from exc
 
-    def _get_contents(self) -> list[PancadThing]:
+    def _get_contents(self) -> list[T]:
         """Returns the full list of contents, including any items in specialized
         indices.
         """
         return self._values
 
     # Private Methods
-    def _raise_if_duped_uid(self, value: PancadThing) -> None:
+    def _raise_if_duped_uid(self, value: T) -> None:
         """Raises a DupeUidError if the geometry's uid is already in the
         list. Used when trying to add geometry to the list.
         """
@@ -73,7 +78,7 @@ class UniqueCADList(MutableSequence, metaclass=ABCMeta):
             msg = f"{self._type_name} {value} uid: {value.uid} already in list."
             raise DupeUidError(msg)
 
-    def _raise_if_has_dependents(self, value: PancadThing) -> None:
+    def _raise_if_has_dependents(self, value: T) -> None:
         """Raises a HasDependentsError if geometry still has
         constraints. Used when trying to delete geometry from list.
         """
@@ -83,18 +88,17 @@ class UniqueCADList(MutableSequence, metaclass=ABCMeta):
 
     # Dunders
     @overload
-    def __getitem__(self, index: int) -> Any: ...
+    def __getitem__(self: UniqueCADList[T], index: int) -> T: ...
     @overload
-    def __getitem__(self, index: slice[int | None, int | None, int | None]
-                    ) -> list[Any]: ...
-    def __getitem__(self, index):
+    def __getitem__(self: UniqueCADList[T], index: ListSlice) -> list[T]: ...
+    def __getitem__(self: UniqueCADList[T], index: int | ListSlice) -> T | list[T]:
         return self._values[index]
 
     @overload
     def __delitem__(self, index: int) -> None: ...
     @overload
-    def __delitem__(self, index: slice[int | None, int | None, int | None]) -> None: ...
-    def __delitem__(self, index):
+    def __delitem__(self, index: ListSlice) -> None: ...
+    def __delitem__(self, index: int | ListSlice) -> None:
         """Deletes the value from the list after checking deletion validity.
 
         :raises HasDependentsError: Raised if the feature still has dependents.
@@ -107,7 +111,7 @@ class UniqueCADList(MutableSequence, metaclass=ABCMeta):
     def __len__(self) -> int:
         return len(self._values)
 
-    def __contains__(self, value: Any) -> bool:
+    def __contains__(self, value: object) -> bool:
         if not isinstance(value, PancadThing):
             return False
         return any(value.uid == element.uid for element in self._get_contents())
@@ -119,7 +123,7 @@ class UniqueCADList(MutableSequence, metaclass=ABCMeta):
         return str(self._values)
 
 
-class SystemFeatureList(UniqueCADList):
+class SystemFeatureList(UniqueCADList[AbstractFeature]):
     """A class managing a mutable list of CAD features inside of a
     FeatureSystem. The list's parent does not contribute to the lists's
     length, but is accessible at index -1.
@@ -162,18 +166,17 @@ class SystemFeatureList(UniqueCADList):
             msg = f"No {self._type_name} with name '{name}' found."
             raise LookupError(msg) from exc
 
-    def _get_contents(self) -> list[PancadThing]:
+    def _get_contents(self) -> list[AbstractFeature]:
         if self._parent.feature is not None:
             return [self._parent.feature] + super()._get_contents()
         return super()._get_contents()
 
-    def missing_dependencies(self,
-                             value: AbstractFeature) -> list[PancadThing]:
+    def missing_dependencies(self, value: AbstractFeature) -> list[PancadThing]:
         """Returns missing feature dependencies for a feature."""
         return [feature for feature in value.get_dependencies()
                 if feature not in self._parent]
 
-    def _raise_if_missing_dependencies(self, value: AbstractFeature):
+    def _raise_if_missing_dependencies(self, value: AbstractFeature) -> None:
         """Raises a MissingCADDependencyError when not all of a constraint's
         dependencies are in the list's system.
         """
@@ -192,11 +195,13 @@ class SystemFeatureList(UniqueCADList):
     @overload
     def __getitem__(self, index: int) -> AbstractFeature: ...
     @overload
-    def __getitem__(self, index: slice[int | None, int | None, int | None]
-                    ) -> list[AbstractFeature]: ...
-    def __getitem__(self, index):
+    def __getitem__(self, index: ListSlice) -> list[AbstractFeature]: ...
+    def __getitem__(self, index: int | ListSlice) -> AbstractFeature | list[AbstractFeature]:
         if index == -1:
-            return self._parent.feature
+            if self._parent.feature:
+                return self._parent.feature
+            msg = "Cannot get the parent system's feature: {self._parent} not in a feature."
+            raise RuntimeError(msg)
         return super().__getitem__(index)
 
     @overload
@@ -204,10 +209,13 @@ class SystemFeatureList(UniqueCADList):
     @overload
     def __setitem__(self, index: slice[int | None, int | None, int | None],
                     value: Iterable[AbstractFeature]) -> None: ...
-    def __setitem__(self, index, value):
+    def __setitem__(self, index: int | ListSlice,
+                    value: AbstractFeature | Iterable[AbstractFeature]) -> None:
         """Replaces object in list and removes the old object's system."""
         if isinstance(index, slice):
             raise NotImplementedError("Cannot use slices with setitem yet, see #281")
+        if not isinstance(value, AbstractFeature):
+            raise NotImplementedError("Cannot set multiple values with setitem yet, see #281")
         self._raise_if_missing_dependencies(value)
         previous_value = self._values[index] # -1 is not allowed here
         if self[index].uid != value.uid:
@@ -218,7 +226,7 @@ class SystemFeatureList(UniqueCADList):
         # Remove the system from exiting element
         previous_value.system = None
 
-class FeatureConstraintList(UniqueCADList):
+class FeatureConstraintList(UniqueCADList[AbstractConstraint]):
     """A class managing the mutable list of constraints between features and
     their dependencies.
     """
@@ -267,7 +275,7 @@ class FeatureConstraintList(UniqueCADList):
         value.system = self._parent
         value.feature = self._parent.feature
 
-    def _raise_if_missing_dependencies(self, value: AbstractConstraint):
+    def _raise_if_missing_dependencies(self, value: AbstractConstraint) -> None:
         """Raises a MissingCADDependencyError when not all of a constraint's
         dependencies are in the list's system.
         """
@@ -279,14 +287,16 @@ class FeatureConstraintList(UniqueCADList):
     @overload
     def __setitem__(self, index: int, value: AbstractConstraint) -> None: ...
     @overload
-    def __setitem__(self, index: slice[int | None, int | None, int | None],
-                    value: Iterable[AbstractConstraint]) -> None: ...
-    def __setitem__(self, index, value):
+    def __setitem__(self, index: ListSlice, value: Iterable[AbstractConstraint]) -> None: ...
+    def __setitem__(self, index: int | ListSlice,
+                    value: AbstractConstraint | Iterable[AbstractConstraint]) -> None:
         """Replaces object in list and removes the old object's system and
         feature.
         """
         if isinstance(index, slice):
             raise NotImplementedError("Cannot use slices with setitem yet, see #281")
+        if not isinstance(value, AbstractConstraint):
+            raise NotImplementedError("Cannot set multiple values with setitem yet, see #281")
         previous_value = self._values[index] # -1 is not allowed here
         self._raise_if_missing_dependencies(value)
         if self[index].uid != value.uid:
@@ -298,7 +308,7 @@ class FeatureConstraintList(UniqueCADList):
         previous_value.system = None
         previous_value.feature = None
 
-class FeatureGeometryList(MutableSequence):
+class FeatureGeometryList(MutableSequence[AbstractGeometry]):
     """A class managing the list of geometry that a feature owns. Feature geometry includes any
     geometry that would need to be deleted if the feature was deleted. This list differs from a
     geometry or constraint list because it is directly owned by a feature rather than existing
@@ -357,16 +367,15 @@ class FeatureGeometryList(MutableSequence):
     @overload
     def __getitem__(self, index: int) -> AbstractGeometry: ...
     @overload
-    def __getitem__(self, index: slice[int | None, int | None, int | None]
-                    ) -> list[AbstractGeometry]: ...
-    def __getitem__(self, index):
+    def __getitem__(self, index: ListSlice) -> list[AbstractGeometry]: ...
+    def __getitem__(self, index: int | ListSlice) -> AbstractGeometry | list[AbstractGeometry]:
         return self._values[index]
 
     @overload
     def __delitem__(self, index: int) -> None: ...
     @overload
-    def __delitem__(self, index: slice[int | None, int | None, int | None]) -> None: ...
-    def __delitem__(self, index):
+    def __delitem__(self, index: ListSlice) -> None: ...
+    def __delitem__(self, index: int | ListSlice) -> None:
         """Deletes object from list and removes its feature."""
         if isinstance(index, slice):
             raise NotImplementedError("Cannot use slices with setitem yet, see #281")
@@ -378,12 +387,14 @@ class FeatureGeometryList(MutableSequence):
     @overload
     def __setitem__(self, index: int, value: AbstractGeometry) -> None: ...
     @overload
-    def __setitem__(self, index: slice[int | None, int | None, int | None],
-                    value: Iterable[AbstractGeometry]) -> None: ...
-    def __setitem__(self, index, value):
+    def __setitem__(self, index: ListSlice, value: Iterable[AbstractGeometry]) -> None: ...
+    def __setitem__(self, index: int | ListSlice,
+                    value: AbstractGeometry | Iterable[AbstractGeometry]) -> None:
         """Replaces object in list and removes the old object's feature."""
         if isinstance(index, slice):
             raise NotImplementedError("Cannot use slices with setitem yet, see #281")
+        if not isinstance(value, AbstractGeometry):
+            raise NotImplementedError("Cannot set multiple values with setitem yet, see #281")
         previous_value = self._values[index]
         if self[index].uid != value.uid:
             self._raise_if_duped_uid(value)
@@ -392,7 +403,7 @@ class FeatureGeometryList(MutableSequence):
         # Remove the feature from exiting geometry
         previous_value.feature = None
 
-    def __contains__(self, value: Any) -> bool:
+    def __contains__(self, value: object) -> bool:
         if not isinstance(value, PancadThing):
             return False
         return any(value.uid == element.uid for element in self._values)
@@ -400,7 +411,7 @@ class FeatureGeometryList(MutableSequence):
     def __len__(self) -> int:
         return len(self._values)
 
-class UniqueSketchElementList(UniqueCADList, metaclass=ABCMeta):
+class UniqueSketchElementList(UniqueCADList[GC], Generic[GC], metaclass=ABCMeta):
     """A class managing the interfaces for CAD sketch lists."""
 
     # Private Methods
@@ -419,8 +430,8 @@ class UniqueSketchElementList(UniqueCADList, metaclass=ABCMeta):
     @overload
     def __delitem__(self, index: int) -> None: ...
     @overload
-    def __delitem__(self, index: slice[int | None, int | None, int | None]) -> None: ...
-    def __delitem__(self, index):
+    def __delitem__(self, index: ListSlice) -> None: ...
+    def __delitem__(self, index: int | ListSlice) -> None:
         """Deletes object from list and removes its system."""
         if isinstance(index, slice):
             raise NotImplementedError("Cannot use slices with delitem yet, see #281")
@@ -430,7 +441,7 @@ class UniqueSketchElementList(UniqueCADList, metaclass=ABCMeta):
         previous_value.system = None
         previous_value.feature = None
 
-class SketchGeometryList(UniqueSketchElementList):
+class SketchGeometryList(UniqueSketchElementList[AbstractGeometry]):
     """A class managing a mutable list of geometry. The list's parent does not
     contribute to the lists's length, but is accessible at index -1.
 
@@ -446,7 +457,7 @@ class SketchGeometryList(UniqueSketchElementList):
                  values: Sequence[AbstractGeometry]) -> None:
         super().__init__(parent, values)
 
-    def _get_contents(self) -> list[PancadThing]:
+    def _get_contents(self) -> list[AbstractGeometry]:
         return [self._parent] + super()._get_contents()
 
     def insert(self, index: int, value: AbstractGeometry) -> None:
@@ -462,9 +473,8 @@ class SketchGeometryList(UniqueSketchElementList):
     @overload
     def __getitem__(self, index: int) -> AbstractGeometry: ...
     @overload
-    def __getitem__(self, index: slice[int | None, int | None, int | None]
-                    ) -> list[AbstractGeometry]: ...
-    def __getitem__(self, index):
+    def __getitem__(self, index: ListSlice) -> list[AbstractGeometry]: ...
+    def __getitem__(self, index: int | ListSlice) -> AbstractGeometry | list[AbstractGeometry]:
         if index == -1:
             return self._parent
         return super().__getitem__(index)
@@ -472,12 +482,14 @@ class SketchGeometryList(UniqueSketchElementList):
     @overload
     def __setitem__(self, index: int, value: AbstractGeometry) -> None: ...
     @overload
-    def __setitem__(self, index: slice[int | None, int | None, int | None],
-                    value: Iterable[AbstractGeometry]) -> None: ...
-    def __setitem__(self, index, value):
+    def __setitem__(self, index: ListSlice, value: Iterable[AbstractGeometry]) -> None: ...
+    def __setitem__(self, index: int | ListSlice,
+                    value: AbstractGeometry | Iterable[AbstractGeometry]) -> None:
         """Replaces object in list and removes the old object's system."""
         if isinstance(index, slice):
             raise NotImplementedError("Cannot use slices with setitem yet, see #281")
+        if not isinstance(value, AbstractGeometry):
+            raise NotImplementedError("Cannot set multiple values with setitem yet, see #281")
         previous_value = self._values[index] # -1 is not allowed here
         if self[index].uid != value.uid:
             self._raise_if_duped_uid(value)
@@ -489,7 +501,7 @@ class SketchGeometryList(UniqueSketchElementList):
         previous_value.feature = None
 
 
-class SketchConstraintList(UniqueSketchElementList):
+class SketchConstraintList(UniqueSketchElementList[AbstractConstraint]):
     """A class managing a mutable list of sketch constraints and their
     dependencies.
 
@@ -520,14 +532,13 @@ class SketchConstraintList(UniqueSketchElementList):
         self._values.insert(index, value)
         self._assign_system(value)
 
-    def missing_dependencies(self, value: AbstractConstraint
-                             ) -> list[AbstractGeometry]:
+    def missing_dependencies(self, value: AbstractConstraint) -> list[AbstractGeometry]:
         """Returns missing geometry dependencies for a constraint."""
         return [geometry for geometry in value.get_parents()
                 if geometry not in self._parent]
 
     # Private Methods
-    def _raise_if_missing_dependencies(self, value: AbstractConstraint):
+    def _raise_if_missing_dependencies(self, value: AbstractConstraint) -> None:
         """Raises a MissingCADDependencyError when not all of a constraint's
         dependencies are in the list's system.
         """
@@ -538,9 +549,9 @@ class SketchConstraintList(UniqueSketchElementList):
     @overload
     def __setitem__(self, index: int, value: AbstractConstraint) -> None: ...
     @overload
-    def __setitem__(self, index: slice[int | None, int | None, int | None],
-                    value: Iterable[AbstractConstraint]) -> None: ...
-    def __setitem__(self, index, value) -> None:
+    def __setitem__(self, index: ListSlice, value: Iterable[AbstractConstraint]) -> None: ...
+    def __setitem__(self, index: int | ListSlice,
+                    value: AbstractConstraint | Iterable[AbstractConstraint]) -> None:
         """Sets the index to the constraint.
 
         :raises MissingCADDependencyError: When not all constraint
@@ -548,6 +559,8 @@ class SketchConstraintList(UniqueSketchElementList):
         """
         if isinstance(index, slice):
             raise NotImplementedError("Cannot use slices with setitem yet, see #281")
+        if not isinstance(value, AbstractConstraint):
+            raise NotImplementedError("Cannot set multiple values with setitem yet, see #281")
         self._raise_if_missing_dependencies(value)
         previous_value = self._values[index] # -1 is not allowed here
         if self[index].uid != value.uid:

--- a/src/pancad/utils/geometry.py
+++ b/src/pancad/utils/geometry.py
@@ -16,6 +16,8 @@ from pancad.utils import trigonometry as trig
 if TYPE_CHECKING:
     from typing import Any
 
+    import numpy.typing as npt
+
     from pancad.utils.pancad_types import SpaceVector, Space3DVector
 
 ### Wrappers
@@ -96,8 +98,7 @@ def no_dimensional_mismatch(func):
     return wrapper
 
 ### Functions
-def parse_vector(*components: Real | Sequence[Real] | np.ndarray
-                 ) -> tuple[Real, Real] | tuple[Real, Real, Real]:
+def parse_vector(*components: float | Sequence[float] | np.NDArray[np.float64]) -> SpaceVector:
     """Batches structures of vector component inputs to a tuple of Reals.
     Usually used by pancad to parse position and direction information into the
     geometry classes.

--- a/src/pancad/utils/trigonometry.py
+++ b/src/pancad/utils/trigonometry.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 from functools import partial
 import math
 from math import degrees
-from typing import Any, TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 import numpy as np
 from numpy.linalg import norm
@@ -37,6 +37,7 @@ def get_unit_vector(vector: SpaceVector | npt.NDArray[np.float64]) -> npt.NDArra
     """Returns the unit vector of the given vector. If the vector is a zero
     vector, returns the zero vector.
     """
+    unit_vector: npt.NDArray[np.float64]
     if isinstance(vector, np.ndarray):
         shape = vector.shape
     else:
@@ -105,10 +106,11 @@ def is_clockwise(vector1: Space2DVector, vector2: Space2DVector) -> bool:
     if len(vector1) == len(vector2) == 2:
         x1, y1 = vector1
         vector1_90_ccw = (-y1, x1)
-        return np.dot(vector1_90_ccw, vector2) < 0
+        # numpy can output an array from dot, so float is called on it here to guarantee the type
+        return float(np.dot(vector1_90_ccw, vector2)) < 0
     raise ValueError("Both vectors must be 2 long")
 
-def is_geometry_vector(vector: np.ndarray) -> bool:
+def is_geometry_vector(vector: npt.NDArray[np.float64]) -> bool:
     """Returns whether the NumPy vector is a valid 2D or 3D vector
 
     :param vector: A NumPy vector to be checked
@@ -116,7 +118,7 @@ def is_geometry_vector(vector: np.ndarray) -> bool:
     """
     return vector.shape in [(2,), (3,), (2,1), (3,1)]
 
-def is_iterable(value: Any) -> bool:
+def is_iterable(value: object) -> bool:
     """Returns whether a value is iterable."""
     return hasattr(value, "__iter__")
 
@@ -210,17 +212,26 @@ def positive_angle(angle: float) -> float:
         return angle_mod(angle)
     return angle_mod(angle) + 2*np.pi
 
-def to_1d_tuple(value: SpaceVector | npt.NDArray[np.float64]) -> tuple:
-    """Returns a 1D tuple from a given value."""
+def to_1d_tuple(value: SpaceVector | npt.NDArray[np.float64]) -> SpaceVector:
+    """Returns a 2D or 3D vector as a tuple from a given value."""
+    tuple_value: tuple[float, ...]
+    # Convert internal values based on the container type
     if isinstance(value, tuple) and not all(map(is_iterable, value)):
-        return value
+        tuple_value = value
     if isinstance(value, list) and not all(map(is_iterable, value)):
-        return tuple(value)
+        tuple_value = tuple(value)
     if isinstance(value, np.ndarray) and is_geometry_vector(value):
-        return tuple(float(coordinate.squeeze()) for coordinate in value)
-    raise ValueError(f"Cannot convert {value} of class {value.__class__}")
+        tuple_value = tuple(float(coordinate.squeeze()) for coordinate in value)
+    # Unpack and return tuple to guarantee length
+    if len(tuple_value) == 2:
+        x, y = tuple_value
+        return (x, y)
+    if len(tuple_value) == 3:
+        x, y, z = tuple_value
+        return (x, y, z)
+    raise ValueError(f"Cannot convert {value} of class {value.__class__} to a 2 or 3 long tuple")
 
-def to_1d_np(value: SpaceVector | npt.NDArray[np.float64]) -> np.ndarray:
+def to_1d_np(value: SpaceVector | npt.NDArray[np.float64]) -> npt.NDArray[np.float64]:
     """Returns a 1D numpy array from a given value."""
     if isinstance(value, tuple) and not all(map(is_iterable, value)):
         return np.array(value)


### PR DESCRIPTION
# Summary

Corrected the static type checking for the geometry.point module. While correcting its typing, I discovered that mypy has to be run with --strict to catch all the non-annotated types, so this update also includes corrections for abstract, trigonometry, and unique_lists. Closes #274

# Changes

1. Added generic types bound to pancadthing and abstractgeometry/constraint for the unique lists
2. Added more NotImplementedErrors for the setitem dunders on unique lists related to #281 
3. Replaced Real with float in Point
4. Added pyproject.toml list of files to maintain typing on. They can be checked with typing:strictdefault
5. Replaced is_equal and update methods types on AbstractGeometry with a generic tied to the specific AbstractGeometry.
6. Finished typing trigonometry with the strict typing. Refactored to_1d_tuple to guarantee its output length is 2 or 3 long.
7. Added all dunder to constants module
8. Replaced np.ndarray with numpy typing NDArray