### PR TITLE
Test/302 line direction around origin

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,7 @@ from functools import cache
 from typing import TYPE_CHECKING
 import tomllib
 from pathlib import Path
+import sys
 
 import pytest
 import quaternion # type: ignore
@@ -208,6 +209,19 @@ def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
     for change_fixture in [f for f in metafunc.fixturenames if f.startswith("changes_")]:
         ids, change_data = _make_geometry_change_input(change_fixture)
         metafunc.parametrize(change_fixture, change_data, ids=ids)
+
+@pytest.fixture(name="min_squareable")
+def fixture_min_squareable() -> float:
+    """Returns the minimum squareable floating point number on this system."""
+    # When the square of a float is smaller than the smallest IEEE subnormal, the new float is
+    # set to 0.
+    info = sys.float_info
+    min_squareable_exp = (info.min_exp - info.mant_dig) // 2
+    squareable_limit = 1 / math.sqrt(info.radix) * info.radix ** min_squareable_exp
+    min_squareable = math.nextafter(squareable_limit, 1)
+    assert squareable_limit**2  == 0 # check the squareable_limit's square is actually 0
+    assert min_squareable**2 != 0 # check that min_squareable's square is actually not 0
+    return min_squareable
 
 @pytest.fixture(name="unconstrained_square_sketch")
 def fixture_unconstrained_square_sketch() -> Sketch:

--- a/tests/geometry/test_line.py
+++ b/tests/geometry/test_line.py
@@ -2,8 +2,6 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
-import math
-import sys
 
 import numpy as np
 import quaternion # type: ignore
@@ -323,7 +321,20 @@ class TestDirectionAroundOrigin:
     """Tests for ensuring the validity of the Line direction behavior around the origin point."""
 
     def test_smallest_direction(self, min_squareable: float) -> None:
-        """Test the repeatability of Line's direction as a unit vector's length approaches 0."""
-        # When the square of a component is smaller than the smallest subnormal, the component is
-        # set to 0.
+        """Test the ability to initialize Line's direction using a vector with the smallest
+        possible float that can still be squared on the system.
+        """
         assert Line(Point(0, 0, 0), (min_squareable, 0, 0)).direction == (1, 0, 0)
+
+    def test_smallest_unique_direction(self, min_squareable: float) -> None:
+        """Test the ability to make the direction vector unique even when the input components are
+        very close to 0.
+        """
+        assert Line(Point(0, 0, 0), (0, 0, -min_squareable)).direction == (0, 0, 1)
+
+    def test_two_smallest_components(self, min_squareable: float) -> None:
+        """Test Line direction initialization with two components starting as close to 0 as
+        possible.
+        """
+        expected = tuple(np.array((1, 1, 0)) / np.linalg.norm((1, 1, 0)))
+        assert Line(Point(0, 0, 0), (min_squareable, min_squareable, 0)).direction == expected

--- a/tests/geometry/test_line.py
+++ b/tests/geometry/test_line.py
@@ -2,6 +2,8 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
+import math
+import sys
 
 import numpy as np
 import quaternion # type: ignore
@@ -316,3 +318,24 @@ class TestSpotChecks:
         axis = Axis((0, 0), (1, 0))
         with pytest.raises(ValueError, match="2D Axis with"):
             axis.rotate(quaternion.quaternion(1, 0, 0, 0))
+
+class TestDirectionAroundOrigin:
+    """Tests for ensuring the validity of the Line direction behavior around the origin point."""
+
+    def test_smallest_vector(self) -> None:
+        """Test the repeatability of Line's direction as a unit vector's length approaches 0."""
+        # First find smallest subnormal number per the IEEE 754 floating-point specification.
+        info = sys.float_info
+        smallest_subnormal = info.radix ** (info.min_exp - info.mant_dig)
+        # Turning the vector into a unit vector requires squaring the vector components as part of
+        # normalization.
+        # When the square of a component is smaller than the smallest subnormal, the component is
+        # set to 0.
+        min_squareable_exp = (info.min_exp - info.mant_dig) // 2
+        squareable_limit = 1 / math.sqrt(info.radix) * info.radix ** min_squareable_exp
+        min_squareable = math.nextafter(squareable_limit, 1)
+        # Check that the test found the smallest squareable number for the system and that Line
+        # can get the direction of a vector that small.
+        assert squareable_limit**2  == 0
+        assert min_squareable**2 != 0
+        assert Line(Point(0, 0, 0), (min_squareable, 0, 0)).direction == (1, 0, 0)

--- a/tests/geometry/test_line.py
+++ b/tests/geometry/test_line.py
@@ -322,20 +322,8 @@ class TestSpotChecks:
 class TestDirectionAroundOrigin:
     """Tests for ensuring the validity of the Line direction behavior around the origin point."""
 
-    def test_smallest_vector(self) -> None:
+    def test_smallest_direction(self, min_squareable: float) -> None:
         """Test the repeatability of Line's direction as a unit vector's length approaches 0."""
-        # First find smallest subnormal number per the IEEE 754 floating-point specification.
-        info = sys.float_info
-        smallest_subnormal = info.radix ** (info.min_exp - info.mant_dig)
-        # Turning the vector into a unit vector requires squaring the vector components as part of
-        # normalization.
         # When the square of a component is smaller than the smallest subnormal, the component is
         # set to 0.
-        min_squareable_exp = (info.min_exp - info.mant_dig) // 2
-        squareable_limit = 1 / math.sqrt(info.radix) * info.radix ** min_squareable_exp
-        min_squareable = math.nextafter(squareable_limit, 1)
-        # Check that the test found the smallest squareable number for the system and that Line
-        # can get the direction of a vector that small.
-        assert squareable_limit**2  == 0
-        assert min_squareable**2 != 0
         assert Line(Point(0, 0, 0), (min_squareable, 0, 0)).direction == (1, 0, 0)


### PR DESCRIPTION
# Summary

Added tests for initializing Line directions using vector components as close to zero as possible on a given system. Closes #302.

# Changes

1. Added min_squareable fixture to provide the smallest floating point number on a system that can be squared without being rounded to 0. This fixture accounts for IEEE subnormal representations, so the minimum possible floating point is smaller than the minimum floating point number printed by python's sys.float_info.
2. Added tests for smallest direction, unique direction, and two components being the smallest floating point value.