### PR TITLE
Feat/308 consolidate unique vector

### DIFF
--- a/src/pancad/geometry/line.py
+++ b/src/pancad/geometry/line.py
@@ -19,7 +19,7 @@ from pancad.abstract import AbstractGeometry
 from pancad.constants import ConstraintReference
 from pancad.geometry.point import Point
 from pancad.utils import trigonometry as trig
-from pancad.utils.geometry import closest_to_origin
+from pancad.utils.geometry import closest_to_origin, get_unique_vector
 
 if TYPE_CHECKING:
     from typing import Self, Optional, Type
@@ -390,30 +390,8 @@ class Line(AbstractGeometry):
         :param vector: A 1D vector of cartesian coordinates.
         :returns: The unique unit vector to represent the vector's direction.
         """
-        unit_vector = trig.get_unit_vector(vector)
-        for i, component in enumerate(unit_vector):
-            # Replace any near-zeros with zero to eliminate ambiguity.
-            if np.isclose(component, 0, atol=self.zero_tol):
-                unit_vector[i] = 0
-        # Ensure the vector is still a unit vector after zeroes are removed
-        unit_vector = trig.get_unit_vector(unit_vector)
-        if len(unit_vector) == 3:
-            x, y, z = unit_vector
-            if x < 0 and y == 0 and z == 0:
-                unit_vector = -unit_vector
-            elif y < 0 and z == 0:
-                unit_vector = -unit_vector
-            elif z < 0:
-                unit_vector = -unit_vector
-
-        elif len(unit_vector) == 2:
-            x, y = unit_vector
-            if x < 0 and y == 0:
-                unit_vector = -unit_vector
-            elif not y == 0 and y < 0:
-                unit_vector = -unit_vector
-        # Add 0 to ensure negative zero representations are eliminated
-        return trig.to_1d_tuple(unit_vector + 0)
+        unit_vector = get_unique_vector(trig.get_unit_vector(vector))
+        return trig.to_1d_tuple(unit_vector)
 
     # Python Dunders #
     def __conform__(self, protocol: Type[PrepareProtocol]) -> str:

--- a/src/pancad/utils/geometry.py
+++ b/src/pancad/utils/geometry.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from functools import wraps
 from itertools import islice
 from collections.abc import Sequence
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, overload
 from numbers import Real
 from warnings import catch_warnings
 
@@ -98,6 +98,31 @@ def no_dimensional_mismatch(func):
     return wrapper
 
 ### Functions
+@overload
+def get_unique_vector(vector: Sequence[float]) -> tuple[float, ...]: ...
+@overload
+def get_unique_vector(vector: Numpy1D) -> Numpy1D: ...
+def get_unique_vector(vector: Sequence[float] | Numpy1D) -> tuple[float, ...] | Numpy1D:
+    """Checks the vector against unique direction rules and inverts it if any are violated.
+
+    Example of the algorithm using 3D vectors:
+    1. The z component must be nonnegative.
+    2. If z is exactly 0 or the vector is 2D, y must be nonnegative.
+    3. If both y and z are exactly 0 or the vector is 2D, x must be nonnegative.
+    4. Zero vectors are considered already unique and returned as is.
+
+    :param vector: An n-dimensional vector.
+    """
+    tuple_vector = tuple(vector)
+    for component in tuple_vector[::-1]:
+        if component < 0:
+            tuple_vector = tuple(map(lambda c: -c, tuple_vector))
+        if component > 0:
+            break
+    if isinstance(vector, np.ndarray):
+        return np.array(tuple_vector)
+    return tuple_vector
+
 def parse_vector(*components: float | Sequence[float] | Numpy1D) -> SpaceVector:
     """Batches structures of vector component inputs to a tuple of Reals.
     Usually used by pancad to parse position and direction information into the

--- a/src/pancad/utils/geometry.py
+++ b/src/pancad/utils/geometry.py
@@ -117,8 +117,11 @@ def get_unique_vector(vector: Sequence[float] | Numpy1D) -> tuple[float, ...] | 
     for component in tuple_vector[::-1]:
         if component < 0:
             tuple_vector = tuple(map(lambda c: -c, tuple_vector))
+            break
         if component > 0:
             break
+    # Add 0 to ensure negative zero representations are eliminated
+    tuple_vector = tuple(map(lambda c: c + 0, tuple_vector))
     if isinstance(vector, np.ndarray):
         return np.array(tuple_vector)
     return tuple_vector

--- a/src/pancad/utils/solver_residuals.py
+++ b/src/pancad/utils/solver_residuals.py
@@ -342,44 +342,14 @@ def line_ref_point(ref_pt: Numpy1D, direction: Numpy1D) -> float:
         # Should only execute when the point is a zero vector.
         return float(np.linalg.norm(ref_pt))
 
-def unique_vector(vector: Numpy1D, zero_atol: float=1e-16) -> Numpy1D:
+def unique_vector(vector: Numpy1D) -> Numpy1D:
     """Calculates how far a vector is into the non-unique set of vectors. All pancad
     non-unique vectors are opposites of a unique vector.
 
-    Unique pancad vectors must meet these conditions:
-
-    1. If 3D, the z component must be nonnegative.
-    2. If 2D or z is 0, the y component must be nonnegative.
-    3. If both y and z is 0, the x component must be nonnegative.
-
     :param vector: A vector that must be unique.
-    :param zero_atol: The absolute tolerance to use when checking whether components are 0.
-    :returns: A numpy array of the residuals for z (if 3D), y, and x.
+    :returns: A numpy array of the residuals for x and y (and z, if 3D).
     """
-    residuals: list[float] = []
-    if len(vector) == 3:
-        x, y, z = vector
-        # If z is the negative zero_atol, this function should treat z as 0 and move to 2D case.
-        # If z is positive zero_atol, this function should treat z as 0 and move to 2D case.
-        # If z is less than negative zero_atol, this function should return the z residual and 0.
-        # If z is a nonzero positive number, this function should return np.array([0, 0]).
-        residuals.append(z - abs(z))
-        if abs(residuals[0]) >= 0 and not np.isclose(z, 0, atol=zero_atol):
-            # z is either positive or is a negative number that is not close to 0.
-            # Should return z residual and 0.
-            residuals.extend([0, 0])
-            return np.array(residuals)
-        # Z must be zero at this point, so the 3D problem reduces to 2D.
-    else:
-        x, y = vector
-    # Direction is 2D or z is 0.
-    if np.isclose(y, 0, atol=zero_atol):
-        # Y is close to 0, so return x residual.
-        residuals.extend([y - abs(y), x - abs(x)])
-    else:
-        # Y is not close to 0, so return y residual.
-        residuals.extend([y - abs(y), 0])
-    return np.array(residuals)
+    return vector - get_unique_vector(vector)
 
 def get_param_sort_key(type_: Type[PancadThing], equation_name: CEN) -> float:
     """Returns the parameter sorting key of the type for the named equation.

--- a/src/pancad/utils/solver_residuals.py
+++ b/src/pancad/utils/solver_residuals.py
@@ -10,10 +10,10 @@ import math
 import numpy as np
 
 from pancad.constants import SketchConstraint as SC, ConstraintEquationName as CEN
-
 from pancad.geometry.line import Axis, Line
 from pancad.geometry.plane import Plane
 from pancad.geometry.point import Point
+from pancad.utils.geometry import get_unique_vector
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -83,26 +83,6 @@ def get_plane_to_point_distance(plane_point: Numpy1D, normal: Numpy1D, point: Nu
     return float(
         np.copysign(np.linalg.norm(distance_vector), np.dot(distance_vector, unit_normal))
     )
-
-def get_unique_vector(vector: Numpy1D) -> Numpy1D:
-    """Checks the vector against unique direction rules and inverts it if any are violated.
-
-    Example of the algorithm using 3D vectors:
-    1. The z component must be nonnegative.
-    2. If z is exactly 0 or the vector is 2D, y must be nonnegative.
-    3. If both y and z are exactly 0 or the vector is 2D, x must be nonnegative.
-    4. Zero vectors are considered already unique and returned as is.
-
-    :param vector: An n-dimensional vector.
-    """
-    for component in vector[::-1]:
-        if component < 0:
-            return -vector
-        if component > 0:
-            return vector
-    return vector
-
-
 
 ################################################################################
 # Residuals

--- a/src/pancad/utils/trigonometry.py
+++ b/src/pancad/utils/trigonometry.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import decimal
 from functools import partial, singledispatch
 import math
+import sys
 from math import degrees
 from typing import TYPE_CHECKING, overload
 from collections.abc import Sequence
@@ -145,7 +146,10 @@ def get_unit_vector(vector: SpaceVector | Numpy1D | Numpy2D) -> Numpy1D | Numpy2
     vector, returns the zero vector.
 
     :raises TypeError: When provided a 0D or >2D numpy array.
-    :raises ValueError: When provided a non 2D or 3D vector or when provided a zero length vector.
+    :raises ValueError: When provided a non 2D/3D vector, a zero length vector, or when
+        normalization fails due to round off caused by the vector's components being too small but
+        not zero.
+    :raises RuntimeError: When the vector normalization step fails due to an unhandled case.
     """
     shape: tuple[int] | tuple[int, int]
     flat_vector = to_1d_np(vector)
@@ -161,6 +165,11 @@ def get_unit_vector(vector: SpaceVector | Numpy1D | Numpy2D) -> Numpy1D | Numpy2
         if np.isclose(length, 0):
             raise ValueError("Expected vector of nonzero length") from exc
         raise
+    if not np.isclose(failed_length := np.linalg.norm(unit_vector), 1):
+        if any(c**2 < sys.float_info.min and c != 0 for c in vector):
+            raise ValueError("Normalization failed, component squares smaller than system"
+                             f" min floating point value {sys.float_info.min}. Got: {vector}")
+        raise RuntimeError(f"Failed to normalize vector {vector}. Result Length: {failed_length}")
     if len(shape) == 1:
         out_1d_vector: Numpy1D = unit_vector.reshape(*shape)
         return out_1d_vector

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -223,6 +223,15 @@ def fixture_min_squareable() -> float:
     assert min_squareable**2 != 0 # check that min_squareable's square is actually not 0
     return min_squareable
 
+@pytest.fixture(name="min_full_precision_squareable")
+def fixture_min_full_precision_squareable() -> float:
+    """Returns the minimum squareable floating point number on this system that still maintains
+    full precision, meaning it is not subnormal.
+    """
+    min_squareable = math.sqrt(sys.float_info.min)
+    assert math.sqrt(min_squareable**2) == min_squareable
+    return min_squareable
+
 @pytest.fixture(name="unconstrained_square_sketch")
 def fixture_unconstrained_square_sketch() -> Sketch:
     """Square sketch with just the lines, no constraints."""

--- a/tests/data/changes_line.toml
+++ b/tests/data/changes_line.toml
@@ -37,7 +37,8 @@ normed_vectors = {direction = [-1, 1]}
 degree_scalars = {phi = 135}
 [move_to_point.2D_X_Axis.to_plus_180]
 vectors = {point = [0, 0], ref_point = [0, 0]}
-normed_vectors = {direction = [1, 0]}
+# Due to Python's math.sin function returning a slightly positive number for pi, 180 is not flipped
+normed_vectors = {direction = [-1, 1.2246467991473532e-16]}
 degree_scalars = {phi = 180}
 [move_to_point.2D_X_Axis.to_neg_45]
 vectors = {point = [0, 0], ref_point = [0, 0]}

--- a/tests/data/data_geo_util_sample.toml
+++ b/tests/data/data_geo_util_sample.toml
@@ -49,3 +49,21 @@ vectors = {input = [1, 1, -1], result = [-1, -1, 1]}
 vectors = {input = [1, -1, 1], result = [1, -1, 1]}
 [unique_vector.3d_ones_vector_x_negative]
 vectors = {input = [-1, 1, 1], result = [-1, 1, 1]}
+
+[residual_unique_vector]
+[residual_unique_vector.3d_x_axis]
+vectors = {input = [1, 0, 0], result = [0, 0, 0]}
+[residual_unique_vector.3d_y_axis]
+vectors = {input = [0, 1, 0], result = [0, 0, 0]}
+[residual_unique_vector.3d_z_axis]
+vectors = {input = [0, 0, 1], result = [0, 0, 0]}
+[residual_unique_vector.3d_negative_x]
+vectors = {input = [-1, 0, 0], result = [-2, 0, 0]}
+[residual_unique_vector.3d_negative_y]
+vectors = {input = [0, -1, 0], result = [0, -2, 0]}
+[residual_unique_vector.3d_negative_z]
+vectors = {input = [0, 0, -1], result = [0, 0, -2]}
+[residual_unique_vector.3d_ones_vector]
+vectors = {input = [1, 1, 1], result = [0, 0, 0]}
+[residual_unique_vector.3d_negative_ones_vector]
+vectors = {input = [-1, -1, -1], result = [-2, -2, -2]}

--- a/tests/data/data_geo_util_sample.toml
+++ b/tests/data/data_geo_util_sample.toml
@@ -1,0 +1,51 @@
+# data_geo_util_sample.toml is a test data file containing geometry definitions for testing the
+# pancad geometry utilities with.
+
+[unique_vector]
+# 2D/3D Zero Vectors
+[unique_vector.2d_zero_vector]
+vectors = {input = [0, 0], result = [0, 0]}
+[unique_vector.3d_zero_vector]
+vectors = {input = [0, 0, 0], result = [0, 0, 0]}
+
+# 2D Axis Vectors
+[unique_vector.2d_x]
+vectors = {input = [1, 0], result = [1, 0]}
+[unique_vector.2d_negative_x]
+vectors = {input = [-1, 0], result = [1, 0]}
+[unique_vector.2d_y]
+vectors = {input = [0, 1], result = [0, 1]}
+[unique_vector.2d_negative_y]
+vectors = {input = [0, -1], result = [0, 1]}
+
+# 2D Ones Vectors
+[unique_vector.2d_ones_vector]
+vectors = {input = [1, 1], result = [1, 1]}
+[unique_vector.2d_ones_vector_x_negative]
+vectors = {input = [-1, 1], result = [-1, 1]}
+[unique_vector.2d_ones_vector_y_negative]
+vectors = {input = [1, -1], result = [-1, 1]}
+
+# 3D Axis Vectors
+[unique_vector.3d_x]
+vectors = {input = [1, 0, 0], result = [1, 0, 0]}
+[unique_vector.3d_negative_x]
+vectors = {input = [-1, 0, 0], result = [1, 0, 0]}
+[unique_vector.3d_y]
+vectors = {input = [0, 1, 0], result = [0, 1, 0]}
+[unique_vector.3d_negative_y]
+vectors = {input = [0, -1, 0], result = [0, 1, 0]}
+[unique_vector.3d_z]
+vectors = {input = [0, 0, 1], result = [0, 0, 1]}
+[unique_vector.3d_negative_z]
+vectors = {input = [0, 0, -1], result = [0, 0, 1]}
+
+# 3D Ones Vectors
+[unique_vector.3d_ones_vector]
+vectors = {input = [1, 1, 1], result = [1, 1, 1]}
+[unique_vector.3d_ones_vector_z_negative]
+vectors = {input = [1, 1, -1], result = [-1, -1, 1]}
+[unique_vector.3d_ones_vector_y_negative]
+vectors = {input = [1, -1, 1], result = [1, -1, 1]}
+[unique_vector.3d_ones_vector_x_negative]
+vectors = {input = [-1, 1, 1], result = [-1, 1, 1]}

--- a/tests/data/data_line_sample.toml
+++ b/tests/data/data_line_sample.toml
@@ -238,9 +238,9 @@ polar_spherical_vectors = {polar_spherical = [1, 135]}
 degree_scalars = {phi = -45}
 
 [point_angle_lines.polar_origin_180]
-vectors = {start = [0, 0], ref_point = [0, 0]}
-normed_vectors = {unique_direction = [1, 0]}
-polar_spherical_vectors = {polar_spherical = [1, 0]}
+# Due to Python's math.sin function returning a slightly positive number for pi, 180 is not flipped
+vectors = {start = [0, 0], ref_point = [0, 0], unique_direction = [-1, 1.2246467991473532e-16]}
+polar_spherical_vectors = {polar_spherical = [1, 180]}
 degree_scalars = {phi = 180}
 
 [point_angle_lines.polar_origin_negative_180]

--- a/tests/geometry/test_line.py
+++ b/tests/geometry/test_line.py
@@ -320,21 +320,29 @@ class TestSpotChecks:
 class TestDirectionAroundOrigin:
     """Tests for ensuring the validity of the Line direction behavior around the origin point."""
 
-    def test_smallest_direction(self, min_squareable: float) -> None:
+    def test_smallest_direction(self, min_full_precision_squareable: float) -> None:
         """Test the ability to initialize Line's direction using a vector with the smallest
         possible float that can still be squared on the system.
         """
-        assert Line(Point(0, 0, 0), (min_squareable, 0, 0)).direction == (1, 0, 0)
+        assert Line(Point(0, 0, 0), (min_full_precision_squareable, 0, 0)).direction == (1, 0, 0)
 
-    def test_smallest_unique_direction(self, min_squareable: float) -> None:
+    def test_smallest_unique_direction(self, min_full_precision_squareable: float) -> None:
         """Test the ability to make the direction vector unique even when the input components are
         very close to 0.
         """
-        assert Line(Point(0, 0, 0), (0, 0, -min_squareable)).direction == (0, 0, 1)
+        assert Line(Point(0, 0, 0), (0, 0, -min_full_precision_squareable)).direction == (0, 0, 1)
 
-    def test_two_smallest_components(self, min_squareable: float) -> None:
+    def test_two_smallest_components(self, min_full_precision_squareable: float) -> None:
         """Test Line direction initialization with two components starting as close to 0 as
         possible.
         """
         expected = tuple(np.array((1, 1, 0)) / np.linalg.norm((1, 1, 0)))
-        assert Line(Point(0, 0, 0), (min_squareable, min_squareable, 0)).direction == expected
+        in_direction = (min_full_precision_squareable, min_full_precision_squareable, 0)
+        assert Line(Point(0, 0, 0), in_direction).direction == expected
+
+    def test_subnormal_direction(self, min_squareable: float) -> None:
+        """Test that the direction raises a ValueError if the vector is so small that roundoff
+        makes the results unreliable.
+        """
+        with pytest.raises(ValueError, match="^Normalization failed"):
+            assert Line(Point(0, 0, 0), (min_squareable, 0, 0)).direction == (1, 0, 0)

--- a/tests/utils/test_geometry_utils.py
+++ b/tests/utils/test_geometry_utils.py
@@ -118,3 +118,26 @@ def test_get_rotation_quat_excs(start, target, err_type, msg):
     """Test the error handling of get_rotation_quat."""
     with pytest.raises(err_type, match=msg):
         geo_utils.get_rotation_quat(start, target)
+
+@pytest.mark.parametrize(
+    "vector, expected",
+    [
+        [(0, 0, 0), (0, 0, 0)],
+        [(1, 1, 1), (1, 1, 1)],
+        [(-1, -1, -1), (1, 1, 1)],
+        [(1, 1, -1), (-1, -1, 1)],
+        [(-1, -1), (1, 1)],
+    ]
+)
+class TestGetUniqueVector:
+    """Tests for calcuating the unique versions of vectors."""
+
+    def test_tuples(self, vector: tuple[float, ...], expected: tuple[float, ...]) -> None:
+        """Test that vectors are converted to their unique versions."""
+        assert geo_utils.get_unique_vector(vector) == expected
+
+    def test_numpy_array(self, vector: tuple[float, ...], expected: tuple[float, ...]) -> None:
+        """Test that a numpy array input returns a numpy array output."""
+        result = geo_utils.get_unique_vector(np.array(vector))
+        assert tuple(result) == expected # Check correct value
+        assert isinstance(result, np.ndarray) # Check that the output is actually a numpy array

--- a/tests/utils/test_geometry_utils.py
+++ b/tests/utils/test_geometry_utils.py
@@ -1,11 +1,15 @@
 """Tests for pancad's geometry utility functions."""
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
 import numpy as np
 import quaternion
 import pytest
 
 import pancad.utils.geometry as geo_utils
+
+if TYPE_CHECKING:
+    from tests._typing import GeometrySampleData
 
 # Test id abbreviations:
 # pt=point, vec=vector, para=parallel, perp=perpendicular, dir=direction
@@ -119,25 +123,26 @@ def test_get_rotation_quat_excs(start, target, err_type, msg):
     with pytest.raises(err_type, match=msg):
         geo_utils.get_rotation_quat(start, target)
 
-@pytest.mark.parametrize(
-    "vector, expected",
-    [
-        [(0, 0, 0), (0, 0, 0)],
-        [(1, 1, 1), (1, 1, 1)],
-        [(-1, -1, -1), (1, 1, 1)],
-        [(1, 1, -1), (-1, -1, 1)],
-        [(-1, -1), (1, 1)],
-    ]
-)
 class TestGetUniqueVector:
     """Tests for calcuating the unique versions of vectors."""
 
-    def test_tuples(self, vector: tuple[float, ...], expected: tuple[float, ...]) -> None:
-        """Test that vectors are converted to their unique versions."""
-        assert geo_utils.get_unique_vector(vector) == expected
+    def test_2d_3d_tuples(self, data_geo_util_sample_unique_vector: GeometrySampleData) -> None:
+        """Test that 2D and 3D vectors are converted to their unique versions."""
+        vectors = data_geo_util_sample_unique_vector["vectors"]
+        assert geo_utils.get_unique_vector(vectors["input"]) == vectors["result"]
 
-    def test_numpy_array(self, vector: tuple[float, ...], expected: tuple[float, ...]) -> None:
-        """Test that a numpy array input returns a numpy array output."""
-        result = geo_utils.get_unique_vector(np.array(vector))
-        assert tuple(result) == expected # Check correct value
+    def test_numpy_array(self, data_geo_util_sample_unique_vector: GeometrySampleData) -> None:
+        """Test that 2D and 3D numpy array inputs return a numpy array output."""
+        vectors = data_geo_util_sample_unique_vector["vectors"]
+        result = geo_utils.get_unique_vector(np.array(vectors["input"]))
+        assert tuple(result) == vectors["result"] # Check correct value
         assert isinstance(result, np.ndarray) # Check that the output is actually a numpy array
+
+    def test_1d_tuple(self) -> None:
+        """Test ability to return unique 1D tuples."""
+        assert geo_utils.get_unique_vector((-1,)) == (1,)
+        assert geo_utils.get_unique_vector((1,)) == (1,)
+
+    def test_0d_tuple(self) -> None:
+        """Test ability to return an empty unique tuple."""
+        assert geo_utils.get_unique_vector(tuple()) == tuple()

--- a/tests/utils/test_system_solver.py
+++ b/tests/utils/test_system_solver.py
@@ -26,6 +26,8 @@ if TYPE_CHECKING:
     from pancad.abstract import AbstractGeometrySystem, AbstractGeometry
     from pancad.utils.pancad_types import SpaceVector, Space3DVector, Numpy1D
 
+    from tests._typing import GeometrySampleData
+
     # Constraints in a system defined here by listing the SketchConstraint and geometry indices.
     ConstraintDef = tuple[SC, tuple[int, ...]]
     SystemTestPair = tuple[ThreeDSketchSystem, ThreeDSketchSystem]
@@ -525,50 +527,14 @@ class TestResiduals:
         assert pcres.perpendicular(np.array(v1, dtype=np.float64),
                                    np.array(v2, dtype=np.float64)) == expected
 
-    @pytest.mark.parametrize(
-        "vector, atol, expected",
-        [ #nu = non-unique
-            # 3D Whole Numbers
-            pytest.param((1,0,0), DEF_0_TOL, (0,0,0), id="3d_nominal_x"),
-            pytest.param((0,1,0), DEF_0_TOL, (0,0,0), id="3d_nominal_y"),
-            pytest.param((0,0,1), DEF_0_TOL, (0,0,0), id="3d_nominal_z"),
-            pytest.param((-1,0,0), DEF_0_TOL, (0,0,-2), id="3d_nu_negative_x"),
-            pytest.param((0,-1,0), DEF_0_TOL, (0,-2,0), id="3d_nu_negative_y"),
-            pytest.param((0,0,-1), DEF_0_TOL, (-2,0,0), id="3d_nu_negative_z"),
-            pytest.param((1,1,0), DEF_0_TOL, (0,0,0), id="3d_nominal_1,1,0"),
-            pytest.param((-1,-1,0), DEF_0_TOL, (0,-2,0), id="3d_nu_-1,-1,0"),
-            pytest.param((-1,-1,1), DEF_0_TOL, (0,0,0), id="3d_nominal_-1,-1,1"),
-            pytest.param((1,1,1), DEF_0_TOL, (0,0,0), id="3d_nominal_1,1,1"),
-            pytest.param((-1,-1,-1), DEF_0_TOL, (-2,0,0), id="3d_nu_-1,-1,-1"),
-
-            # 3D Near Zeros
-            pytest.param((1,DEF_0_TOL,0), DEF_0_TOL, (0,0,0), id="3d_x_with_plus_0tol_y"),
-            pytest.param((1,-DEF_0_TOL,0), DEF_0_TOL, (0,-2*DEF_0_TOL,0),
-                         id="3d_x_with_minus_0tol_y"),
-            pytest.param((1,-DEF_0_TOL,-DEF_0_TOL), DEF_0_TOL, (-2*DEF_0_TOL,-2*DEF_0_TOL,0),
-                         id="3d_x_with_minus_0tol_y_and_z"),
-            pytest.param((1,1,-DEF_0_TOL), DEF_0_TOL, (-2*DEF_0_TOL,0,0),
-                         id="3d_1,1,0_with_minus_0tol_z"),
-
-            # 2D
-            pytest.param((1,0), DEF_0_TOL, (0,0), id="2d_nominal_x"),
-            pytest.param((0,1), DEF_0_TOL, (0,0), id="2d_nominal_y"),
-            pytest.param((1,0), DEF_0_TOL, (0,0), id="2d_nominal_x"),
-            pytest.param((-1,0), DEF_0_TOL, (0,-2), id="2d_nu_negative_x"),
-            pytest.param((0,-1), DEF_0_TOL, (-2,0), id="2d_nu_negative_y"),
-
-            # 2D Near Zeros
-            pytest.param((1,DEF_0_TOL), DEF_0_TOL, (0,0), id="2d_x_with_plus_0tol_y"),
-            pytest.param((1,-DEF_0_TOL), DEF_0_TOL, (-2*DEF_0_TOL,0),
-                         id="2d_x_with_minus_0tol_y"),
-        ]
-    )
-    def test_unique_direction(self, vector: SpaceVector, atol: float,
-                              expected: tuple[float, float]) -> None:
-        v = np.array(vector)
-        exp = np.array(expected)
-        atol = np.float64(atol)
-        np.testing.assert_array_equal(pcres.unique_vector(v, zero_atol=atol), exp)
+    def test_unique_vector(self, data_geo_util_sample_residual_unique_vector: GeometrySampleData
+                           ) -> None:
+        """Test that unique vector residuals are calculated to be zero vectors when unique and the
+        expected error vector when not unique.
+        """
+        vectors = data_geo_util_sample_residual_unique_vector["vectors"]
+        np.testing.assert_array_equal(pcres.unique_vector(np.array(vectors["input"])),
+                                      np.array(vectors["result"]))
 
     @pytest.mark.parametrize(
         "plane, point, distance, expected",

--- a/tests/utils/test_system_solver.py
+++ b/tests/utils/test_system_solver.py
@@ -670,35 +670,6 @@ class TestResidualHelpers:
             raise
 
     @pytest.mark.parametrize(
-        "vector, expected",
-        [
-            # 0D
-            pytest.param(tuple(), tuple(), id="0d"),
-
-            # 1D
-            pytest.param((0,), (0,), id="zero_vector_1d"),
-            pytest.param((1,), (1,), id="1_1d"),
-            pytest.param((-1,), (1,), id="-1_1d"),
-            # 2D
-            pytest.param((0,0), (0,0), id="zero_vector_2d"),
-            # 3D
-            pytest.param((0,0,0), (0,0,0), id="zero_vector_3d"),
-            pytest.param((1,0,0), (1,0,0), id="x_3d"),
-            pytest.param((-1,0,0), (1,0,0), id="-x_3d"),
-            pytest.param((0,1,0), (0,1,0), id="y_3d"),
-            pytest.param((0,-1,0), (0,1,0), id="-y_3d"),
-            pytest.param((0,0,1), (0,0,1), id="z_3d"),
-            pytest.param((0,0,-1), (0,0,1), id="-z_3d"),
-            pytest.param((-1,-1,-1), (1,1,1), id="-1-1-1_3d"),
-            pytest.param((-1,-1,EPS_64), (-1,-1,EPS_64), id="-1-1eps_3d"),
-            pytest.param((-1,-1,-EPS_64), (1,1,EPS_64), id="-1-1-eps_3d"),
-        ]
-    )
-    def test_get_unique_vector(self, vector: tuple[float, ...], expected: tuple[float, ...]):
-        result = pcres.get_unique_vector(np.array(vector))
-        np.testing.assert_array_equal(result, expected)
-
-    @pytest.mark.parametrize(
         "plane, point, expected",
         [
             ### Moving Point around the XY plane.


### PR DESCRIPTION
# Summary

Moved all get_unique_vector logic into the utils.geometry module as an overloaded get_unique_vector function. Replaced all alternative logic in Line, Axis, and solver_residuals with the new consolidated logic. Closes #308 

# Changes

1. utils.geometry.get_unique_vector is an expanded version of the one that was in solver_residuals originally since it can take a tuple/numpy array and return the same type as its input to make sure it works in as many contexts as possible.
2. Added a possible ValueError for get_unit_vector that can occur if the original vector has a length that can only be represented as a subnormal floating point number. Roundoff can cause the normalization to fail and produce unpredictable results, so it should be handled in a higher context if it does come up.
3. Added fixtures for the smallest possible squareable number and the smallest squareable number with full precision. These can be used to confirm what happens at the smallest scales that python's system floating point numbers can handle.
4. The Line's phi being set to 180 (pi) no longer flips the direction vector to the positive x axis. Python's math.sin function produces a slightly positive number for the y value, so the vector is technically still unique. I decided that it's better to take Python's better documented behavior as-is and handle it in a more specific context if the rounding of a unique vector becomes a problem.
5. Added data_ tests for unique vector solving and for the calculation of system residuals. Removed the existing long parameter lists.
6. Replaced unique_vector logic with just a subtraction of the expected unique vector from the actual vector. Removed the now unused zero_atol argument.