### PR TITLE
Lint/315 constraint types

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,6 +129,7 @@ force-build = [
 [tool.mypy]
 files = [
     "src/pancad/abstract.py",
+    "src/pancad/constraints/snapto.py",
     "src/pancad/geometry/plane.py",
     "src/pancad/geometry/point.py",
     "src/pancad/geometry/line.py",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,6 +132,7 @@ files = [
     "src/pancad/constraints/snapto.py",
     "src/pancad/constraints/state_constraint.py",
     "src/pancad/constraints/distance.py",
+    "src/pancad/constraints/_generator.py",
     "src/pancad/geometry/plane.py",
     "src/pancad/geometry/point.py",
     "src/pancad/geometry/line.py",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -156,5 +156,6 @@ files = [
     "tests/geometry/test_point.py",
     "tests/geometry/test_line.py",
     "tests/geometry/test_coordinate_system.py",
+    "tests/geometry/test_make_constraint.py",
     "tests/testing_utils/plotting.py",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,6 +130,7 @@ force-build = [
 files = [
     "src/pancad/abstract.py",
     "src/pancad/constraints/snapto.py",
+    "src/pancad/constraints/state_constraint.py",
     "src/pancad/geometry/plane.py",
     "src/pancad/geometry/point.py",
     "src/pancad/geometry/line.py",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,6 +131,7 @@ files = [
     "src/pancad/abstract.py",
     "src/pancad/constraints/snapto.py",
     "src/pancad/constraints/state_constraint.py",
+    "src/pancad/constraints/distance.py",
     "src/pancad/geometry/plane.py",
     "src/pancad/geometry/point.py",
     "src/pancad/geometry/line.py",

--- a/src/pancad/abstract.py
+++ b/src/pancad/abstract.py
@@ -11,7 +11,7 @@ from pancad.constants import ConstraintReference
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
-    from typing import Self, Optional, Any, Type, TypeVar
+    from typing import Self, Optional, Any, Type, TypeVar, ClassVar
     from uuid import UUID
 
     T = TypeVar("T")
@@ -282,6 +282,10 @@ class AbstractConstraint(PancadThing):
     """A class defining the interfaces provided by all pancad Constraint
     Elements.
     """
+
+    type_name: ClassVar[SketchConstraint]
+    """The SketchConstraint enum value for the constraint type."""
+
     def __init__(self,
                  system: Optional[AbstractGeometrySystem]=None) -> None:
         super().__init__(system)
@@ -329,12 +333,6 @@ class AbstractConstraint(PancadThing):
     @system.setter
     def system(self, value: Optional[AbstractGeometrySystem]) -> None:
         self._system = value
-
-    # Abstract Properties
-    @property
-    @abstractmethod
-    def type_name(self) -> SketchConstraint:
-        """Returns the SketchConstraint enum value for the constraint type."""
 
     # Public Methods
     def get_dependencies(self) -> list[PancadThing]:

--- a/src/pancad/constraints/_generator.py
+++ b/src/pancad/constraints/_generator.py
@@ -15,7 +15,7 @@ from pancad.constraints.state_constraint import (
 )
 
 if TYPE_CHECKING:
-    from typing import Type
+    from typing import Type, NoReturn
     from uuid import UUID
 
     from pancad.abstract import AbstractGeometry, AbstractConstraint, AbstractGeometrySystem
@@ -47,22 +47,37 @@ _NON_VALUE_CONSTRAINT_MAP: dict[SketchConstraint, Type[NonValueConstraint]] = {
     SketchConstraint.VERTICAL: Vertical,
 }
 
+# Non Value Constraint Overloads
 @overload
-def make_constraint(type_: SketchConstraint | str, *geometry: AbstractGeometry,
-                    uid: UUID | str | None) -> NonValueConstraint: ...
+def make_constraint(type_: SketchConstraint | str,
+                    *geometry: AbstractGeometry,
+                    system: AbstractGeometrySystem | None=None,
+                    uid: UUID | str | None=None,
+                    value: None=None,
+                    unit: None=None,
+                    is_radians: None=None,
+                    quadrant: None=None) -> NonValueConstraint: ...
 @overload
-def make_constraint(type_: SketchConstraint | str, *geometry: AbstractGeometry,
-                    uid: UUID | str | None, value: float, unit: str | None,
-                    ) -> AbstractDistance: ...
+def make_constraint(type_: SketchConstraint | str,
+                    *geometry: AbstractGeometry,
+                    value: float,
+                    unit: str | None=None,
+                    system: AbstractGeometrySystem | None=None,
+                    uid: UUID | str | None=None,
+                    quadrant: None=None,
+                    is_radians: None=None) -> AbstractDistance: ...
 @overload
-def make_constraint(type_: SketchConstraint | str, *geometry: AbstractGeometry,
-                    uid: UUID | str | None, value: float,
-                    unit: None, quadrant: int, is_radians: bool) -> Angle: ...
-@overload
-def make_constraint(type_: SketchConstraint, *geometry: AbstractGeometry,
-                    uid: UUID | str | None, value: float, quadrant: int) -> Angle: ...
+def make_constraint(type_: SketchConstraint | str,
+                    *geometry: AbstractGeometry,
+                    value: float,
+                    quadrant: int,
+                    is_radians: bool | None=None,
+                    system: AbstractGeometrySystem | None=None,
+                    uid: UUID | str | None=None,
+                    unit: None=None) -> Angle: ...
 
-def make_constraint(type_: SketchConstraint | str, *geometry: AbstractGeometry,
+def make_constraint(type_: SketchConstraint | str,
+                    *geometry: AbstractGeometry,
                     uid: UUID | str | None=None,
                     value: float | None=None,
                     unit: str | None=None,
@@ -73,43 +88,44 @@ def make_constraint(type_: SketchConstraint | str, *geometry: AbstractGeometry,
 
     :param type_: The SketchConstraint enumeration value for the constraint to be created.
     :param geometry: The geometry elements to be constrained.
+    :param uid: The constraint's uid. Is auto-generated when None is provided.
     :param value: The constraint's associated value. Can be a length or an angle and is required
         for value constraints.
-    :param uid: The constraint's uid. Is auto-generated when None is provided.
     :param unit: The unit used for the constraint. Defaults to None.
     :param quadrant: The quadrant an angle constraint should appear in. Defaults to None but must
         be given for angle constraints.
     :param is_radians: Whether the value of an angle constraint is provided in radians.
+    :param system: The geometry system context for the constraint.
     :returns: The new pancad constraint.
-    :raises ValueError: If an incompatible argument for the constraint type is not None or when a
-        necessary argument for the constraint type has not been provided.
+    :raises ValueError: When a necessary argument for the constraint type has not been provided.
+        Arguments that are not required for the constraint are ignored.
     """
-    type_ = SketchConstraint(type_)
+    type_ = SketchConstraint(str(type_).lower())
     kwargs = {"value": value, "unit": unit, "quadrant": quadrant, "is_radians": is_radians}
-    if type_ in _DISTANCE_MAP or type_ == SketchConstraint.ANGLE:
+    if type_ in _DISTANCE_MAP:
+        # Creating a Distance constraint.
         if value is None: # Both Distances and Angles need value.
-            raise ValueError(f"value must be provided for {type_} constraints")
-        if type_ in _DISTANCE_MAP:
-            # Creating a Distance constraint.
-            if none_arg := next((k for k in ("quadrant", "is_radians") if kwargs[k] is not None),
-                                None):
-                raise ValueError(f"{none_arg} must be None for {type_} constraints")
-            return _DISTANCE_MAP[type_](*geometry, value=value, uid=uid, unit=unit, system=system)
+            _raise_missing(type_, {"value"}, dict(kwargs))
+        return _DISTANCE_MAP[type_](*geometry, value=value, uid=uid, unit=unit, system=system)
+    if type_ == SketchConstraint.ANGLE:
         # Creating an Angle constraint
-        if quadrant is None:
-            raise ValueError("quadrant must be provided for Angle constraints")
+        if quadrant is None or value is None:
+            _raise_missing(type_, {"value", "quadrant"}, dict(kwargs))
         if is_radians is None:
             return Angle(*geometry, value=value, quadrant=quadrant, uid=uid, system=system)
         return Angle(*geometry, value=value, quadrant=quadrant, is_radians=is_radians,
                      uid=uid, system=system)
-    # Constraint has been confirmed to not be a value constraint past this point.
-    if none_arg := next((k for k, v in kwargs.items() if v is not None), None):
-        # All keyword arguments must be None for non value constraints.
-        raise ValueError(f"{none_arg} must be None for {type_} constraints")
     try:
-        non_value_type = _NON_VALUE_CONSTRAINT_MAP[type_]
+        non_value_constraint_type = _NON_VALUE_CONSTRAINT_MAP[type_]
     except KeyError as exc:
         if type_ in {SketchConstraint.SYMMETRIC, SketchConstraint.TANGENT}:
             raise NotImplementedError("See issue #82 or #85") from exc
         raise NotImplementedError(f"Unsupported SketchConstraint type: {type_}") from exc
-    return non_value_type(*geometry, uid=uid, system=system)
+    return non_value_constraint_type(*geometry, uid=uid, system=system)
+
+def _raise_missing(type_: SketchConstraint, must_have: set[str],
+                   kwargs: dict[str, object]) -> NoReturn:
+    # Raises a ValueError describing each missing argument for the constraint type.
+    missing = ", ".join([k for k, v in kwargs.items() if k in must_have and v is None])
+    assert missing != "" # Ensure that this function wasn't called accidentally
+    raise ValueError(f"'{missing}' was not provided and is required for {type_} constraints")

--- a/src/pancad/constraints/_generator.py
+++ b/src/pancad/constraints/_generator.py
@@ -5,46 +5,39 @@ from __future__ import annotations
 
 from typing import overload, TYPE_CHECKING
 
+from pancad.abstract import AbstractConstraint
 from pancad.constants import SketchConstraint
-from pancad.constraints.distance import (
-    Angle, Diameter, Distance, HorizontalDistance, Radius, VerticalDistance
-)
-from pancad.constraints.snapto import Horizontal, Vertical, Fixed, Unique
-from pancad.constraints.state_constraint import (
-    Coincident, Equal, Parallel, Perpendicular, AlignAxes, Antiparallel, Codirectional
-)
+from pancad.constraints import distance, snapto, state_constraint
+from pancad.constraints.distance import AbstractDistance, Angle
+from pancad.constraints.snapto import AbstractSnapTo, AbstractSingleSnapTo
+from pancad.constraints.state_constraint import AbstractStateConstraint
 
 if TYPE_CHECKING:
     from typing import Type, NoReturn
     from uuid import UUID
 
-    from pancad.abstract import AbstractGeometry, AbstractConstraint, AbstractGeometrySystem
-    from pancad.constraints.distance import AbstractDistance
-    from pancad.constraints.state_constraint import AbstractStateConstraint
-    from pancad.constraints.snapto import AbstractSnapTo, AbstractSingleSnapTo
+    from pancad.abstract import AbstractGeometry, AbstractGeometrySystem
 
     NonValueConstraint = AbstractStateConstraint | AbstractSnapTo | AbstractSingleSnapTo
 
-_DISTANCE_MAP: dict[SketchConstraint, Type[AbstractDistance]] = {
-    SketchConstraint.DISTANCE: Distance,
-    SketchConstraint.DISTANCE_DIAMETER: Diameter,
-    SketchConstraint.DISTANCE_RADIUS: Radius,
-    SketchConstraint.DISTANCE_HORIZONTAL: HorizontalDistance,
-    SketchConstraint.DISTANCE_VERTICAL: VerticalDistance,
-}
+def _all_constraints() -> list[Type[AbstractConstraint]]:
+    # Returns a list of all concrete constraint types in pancad.
+    constraints = []
+    for module in (distance, snapto, state_constraint):
+        for name in dir(module):
+            attr = getattr(module, name, None)
+            if not isinstance(attr, type):
+                # Not a class, skip
+                continue
+            if issubclass(attr, AbstractConstraint) and hasattr(attr, "type_name"):
+                # A concrete subclass of AbstractConstraint
+                constraints.append(attr)
+    return constraints
 
-_NON_VALUE_CONSTRAINT_MAP: dict[SketchConstraint, Type[NonValueConstraint]] = {
-    SketchConstraint.ALIGN_AXES: AlignAxes,
-    SketchConstraint.ANTIPARALLEL: Antiparallel,
-    SketchConstraint.CODIRECTIONAL: Codirectional,
-    SketchConstraint.COINCIDENT: Coincident,
-    SketchConstraint.HORIZONTAL: Horizontal,
-    SketchConstraint.EQUAL: Equal,
-    SketchConstraint.FIXED: Fixed,
-    SketchConstraint.PARALLEL: Parallel,
-    SketchConstraint.PERPENDICULAR: Perpendicular,
-    SketchConstraint.UNIQUE: Unique,
-    SketchConstraint.VERTICAL: Vertical,
+_DISTANCE_MAP = {t.type_name: t for t in _all_constraints() if issubclass(t, AbstractDistance)}
+_NON_VALUE_CONSTRAINT_MAP = {
+    t.type_name: t for t in _all_constraints()
+    if issubclass(t, (AbstractStateConstraint, AbstractSnapTo, AbstractSingleSnapTo))
 }
 
 # Non Value Constraint Overloads

--- a/src/pancad/constraints/_generator.py
+++ b/src/pancad/constraints/_generator.py
@@ -1,5 +1,5 @@
-"""A module providing functions to generate pancad constraints without calling
-each constraint class individually.
+"""A module providing functions to generate pancad constraints without calling each constraint
+class individually.
 """
 from __future__ import annotations
 
@@ -15,27 +15,30 @@ from pancad.constraints.state_constraint import (
 )
 
 if TYPE_CHECKING:
+    from typing import Type
     from uuid import UUID
-    from numbers import Real
 
-    from pancad.abstract import AbstractGeometry, AbstractConstraint
+    from pancad.abstract import AbstractGeometry, AbstractConstraint, AbstractGeometrySystem
     from pancad.constraints.distance import AbstractDistance
     from pancad.constraints.state_constraint import AbstractStateConstraint
-    from pancad.constraints.snapto import AbstractSnapTo
-    from pancad.geometry.constants import ConstraintReference
+    from pancad.constraints.snapto import AbstractSnapTo, AbstractSingleSnapTo
 
-SKETCH_CONSTRAINT_TO_CLASS = {
-    SketchConstraint.ALIGN_AXES: AlignAxes,
-    SketchConstraint.ANTIPARALLEL: Antiparallel,
-    SketchConstraint.ANGLE: Angle,
-    SketchConstraint.CODIRECTIONAL: Codirectional,
-    SketchConstraint.COINCIDENT: Coincident,
-    SketchConstraint.HORIZONTAL: Horizontal,
+    NonValueConstraint = AbstractStateConstraint | AbstractSnapTo | AbstractSingleSnapTo
+
+_DISTANCE_MAP: dict[SketchConstraint, Type[AbstractDistance]] = {
     SketchConstraint.DISTANCE: Distance,
     SketchConstraint.DISTANCE_DIAMETER: Diameter,
     SketchConstraint.DISTANCE_RADIUS: Radius,
     SketchConstraint.DISTANCE_HORIZONTAL: HorizontalDistance,
     SketchConstraint.DISTANCE_VERTICAL: VerticalDistance,
+}
+
+_NON_VALUE_CONSTRAINT_MAP: dict[SketchConstraint, Type[NonValueConstraint]] = {
+    SketchConstraint.ALIGN_AXES: AlignAxes,
+    SketchConstraint.ANTIPARALLEL: Antiparallel,
+    SketchConstraint.CODIRECTIONAL: Codirectional,
+    SketchConstraint.COINCIDENT: Coincident,
+    SketchConstraint.HORIZONTAL: Horizontal,
     SketchConstraint.EQUAL: Equal,
     SketchConstraint.FIXED: Fixed,
     SketchConstraint.PARALLEL: Parallel,
@@ -45,43 +48,68 @@ SKETCH_CONSTRAINT_TO_CLASS = {
 }
 
 @overload
-def make_constraint(type_: SketchConstraint, *geometry: AbstractGeometry,
-                    uid: UUID | str=None
-                    ) -> AbstractStateConstraint | AbstractSnapTo | Fixed: ...
-
+def make_constraint(type_: SketchConstraint | str, *geometry: AbstractGeometry,
+                    uid: UUID | str | None) -> NonValueConstraint: ...
 @overload
-def make_constraint(type_: SketchConstraint, *geometry: AbstractGeometry,
-                    value: Real, unit: str | None=None, uid: UUID | str=None
+def make_constraint(type_: SketchConstraint | str, *geometry: AbstractGeometry,
+                    uid: UUID | str | None, value: float, unit: str | None,
                     ) -> AbstractDistance: ...
-
+@overload
+def make_constraint(type_: SketchConstraint | str, *geometry: AbstractGeometry,
+                    uid: UUID | str | None, value: float,
+                    unit: None, quadrant: int, is_radians: bool) -> Angle: ...
 @overload
 def make_constraint(type_: SketchConstraint, *geometry: AbstractGeometry,
-                    value: Real, uid: UUID | str=None,
-                    quadrant: int, is_radians: bool=False) -> Angle: ...
+                    uid: UUID | str | None, value: float, quadrant: int) -> Angle: ...
 
-def make_constraint(type_, *geometry, **kwargs) -> AbstractConstraint:
+def make_constraint(type_: SketchConstraint | str, *geometry: AbstractGeometry,
+                    uid: UUID | str | None=None,
+                    value: float | None=None,
+                    unit: str | None=None,
+                    quadrant: int | None=None,
+                    is_radians: bool | None=None,
+                    system: AbstractGeometrySystem | None=None) -> AbstractConstraint:
     """Creates a new pancad constraint.
-    
-    :param type_: The SketchConstraint value for the constraint to be created.
-    :param reference_pairs: The (AbstractGeometry, ConstraintReference) pairs of 
-        the geometry to be constrained.
-    :param value: The constraint's associate value. Can be a length or an angle 
-        and is required for value constraints.
-    :param uid: The constraint's uid. Defaults to being auto-generated.
+
+    :param type_: The SketchConstraint enumeration value for the constraint to be created.
+    :param geometry: The geometry elements to be constrained.
+    :param value: The constraint's associated value. Can be a length or an angle and is required
+        for value constraints.
+    :param uid: The constraint's uid. Is auto-generated when None is provided.
     :param unit: The unit used for the constraint. Defaults to None.
-    :param quadrant: The quadrant an angle constraint should appear in. Defaults 
-        to None but must be given for angle constraints.
-    :param is_radians: Whether the value provided for an angle constraint is 
-        provided in radians. Defaults to False.
+    :param quadrant: The quadrant an angle constraint should appear in. Defaults to None but must
+        be given for angle constraints.
+    :param is_radians: Whether the value of an angle constraint is provided in radians.
     :returns: The new pancad constraint.
-    :raises KeyError: Raised if the SketchConstraint is not recognized.
-    :raises NotImplementedError: Raised if a SketchConstraint for a constraint 
-        that is not yet implemented is provided.
+    :raises ValueError: If an incompatible argument for the constraint type is not None or when a
+        necessary argument for the constraint type has not been provided.
     """
+    type_ = SketchConstraint(type_)
+    kwargs = {"value": value, "unit": unit, "quadrant": quadrant, "is_radians": is_radians}
+    if type_ in _DISTANCE_MAP or type_ == SketchConstraint.ANGLE:
+        if value is None: # Both Distances and Angles need value.
+            raise ValueError(f"value must be provided for {type_} constraints")
+        if type_ in _DISTANCE_MAP:
+            # Creating a Distance constraint.
+            if none_arg := next((k for k in ("quadrant", "is_radians") if kwargs[k] is not None),
+                                None):
+                raise ValueError(f"{none_arg} must be None for {type_} constraints")
+            return _DISTANCE_MAP[type_](*geometry, value=value, uid=uid, unit=unit, system=system)
+        # Creating an Angle constraint
+        if quadrant is None:
+            raise ValueError("quadrant must be provided for Angle constraints")
+        if is_radians is None:
+            return Angle(*geometry, value=value, quadrant=quadrant, uid=uid, system=system)
+        return Angle(*geometry, value=value, quadrant=quadrant, is_radians=is_radians,
+                     uid=uid, system=system)
+    # Constraint has been confirmed to not be a value constraint past this point.
+    if none_arg := next((k for k, v in kwargs.items() if v is not None), None):
+        # All keyword arguments must be None for non value constraints.
+        raise ValueError(f"{none_arg} must be None for {type_} constraints")
     try:
-        class_ = SKETCH_CONSTRAINT_TO_CLASS[type_]
-    except KeyError as err:
-        if type_ in [SketchConstraint.SYMMETRIC, SketchConstraint.TANGENT]:
-            raise NotImplementedError("See issue #82 or #85") from err
-        raise KeyError from err
-    return class_(*geometry, **kwargs)
+        non_value_type = _NON_VALUE_CONSTRAINT_MAP[type_]
+    except KeyError as exc:
+        if type_ in {SketchConstraint.SYMMETRIC, SketchConstraint.TANGENT}:
+            raise NotImplementedError("See issue #82 or #85") from exc
+        raise NotImplementedError(f"Unsupported SketchConstraint type: {type_}") from exc
+    return non_value_type(*geometry, uid=uid, system=system)

--- a/src/pancad/constraints/distance.py
+++ b/src/pancad/constraints/distance.py
@@ -14,8 +14,6 @@ from pancad.abstract import AbstractConstraint
 from pancad.constants import SketchConstraint
 
 if TYPE_CHECKING:
-    from numbers import Real
-
     from pancad.abstract import AbstractGeometry, AbstractGeometrySystem
     from pancad.constants import ConstraintReference
 
@@ -26,10 +24,10 @@ class AbstractValue(AbstractConstraint):
     VALUE_STR_FORMAT = "{value}{unit}"
     @property
     @abstractmethod
-    def value(self) -> Real:
+    def value(self) -> float:
         """The value that the constraint enforces."""
     @property
-    def unit(self) -> str:
+    def unit(self) -> str | None:
         """The unit of the constraint's value.
 
         :getter: Returns the constraint's unit.
@@ -37,7 +35,7 @@ class AbstractValue(AbstractConstraint):
         """
         return self._unit
     @unit.setter
-    def unit(self, value: str) -> None:
+    def unit(self, value: str | None) -> None:
         self._unit = value
     # Shared Public Methods #
     def get_value_string(self, include_unit: bool=True) -> str:
@@ -87,11 +85,11 @@ class Angle(AbstractValue):
 
     def __init__(self,
                  *geometry: AbstractGeometry,
-                 value: Real,
+                 value: float,
                  quadrant: int,
-                 uid: str=None,
+                 uid: str | None=None,
                  is_radians: bool=False,
-                 system: AbstractGeometrySystem=None) -> None:
+                 system: AbstractGeometrySystem | None=None) -> None:
         if len(geometry) != 2:
             raise ValueError(f"Expected 2 geometries, provided {geometry}")
         if any(len(g) != 2 for g in geometry):
@@ -122,18 +120,18 @@ class Angle(AbstractValue):
         self._quadrant = value
 
     @property
-    def value(self) -> Real:
+    def value(self) -> float:
         """Value of the angle constraint in degrees.
 
-        :raises TypeError: When the value is not a Real number.
+        :raises TypeError: When the value is not a number.
         """
         return self._value
     @value.setter
-    def value(self, value: Real) -> None:
+    def value(self, value: float) -> None:
         self._value = value
 
     # Public Methods #
-    def get_value(self, in_radians: bool=False) -> Real:
+    def get_value(self, in_radians: bool=False) -> float:
         """Returns the value of the angle constraint.
 
         :param in_radians: Whether to return the value in radians or degrees.
@@ -150,7 +148,7 @@ class AbstractDistance(AbstractValue):
     geometries that has a distance associated with it.
     """
     @property
-    def value(self) -> Real:
+    def value(self) -> float:
         """The distance the constraint enforces. When distance direction can be well-defined, the
         first direction-dependent geometry defines how positive distance is defined. Ex: The
         first plane's normal vector of two constrained planes is the direction of positive
@@ -158,7 +156,7 @@ class AbstractDistance(AbstractValue):
         """
         return self._value
     @value.setter
-    def value(self, value: Real) -> None:
+    def value(self, value: float) -> None:
         self._value = value
 
 class Abstract2GeometryDistance(AbstractDistance):
@@ -175,8 +173,8 @@ class Abstract2GeometryDistance(AbstractDistance):
         not the same dimension.
     """
     def __init__(self, *geometry: AbstractGeometry,
-                 value: Real, uid: str=None, unit: str=None,
-                 system: AbstractGeometrySystem=None) -> None:
+                 value: float, uid: str | None=None, unit: str | None=None,
+                 system: AbstractGeometrySystem | None=None) -> None:
         self.uid = uid
         super().__init__(system)
         if len(geometry) != 2:
@@ -199,8 +197,8 @@ class Abstract1GeometryDistance(AbstractDistance):
     :param unit: The unit of the distance value. Defaults to None.
     """
     def __init__(self, geometry: AbstractGeometry,
-                 value: Real, uid: str=None, unit: str=None,
-                 system: AbstractGeometrySystem=None) -> None:
+                 value: float, uid: str | None=None, unit: str | None=None,
+                 system: AbstractGeometrySystem | None=None) -> None:
         self.uid = uid
         super().__init__(system)
         self._geometry = [geometry]

--- a/src/pancad/constraints/distance.py
+++ b/src/pancad/constraints/distance.py
@@ -20,11 +20,14 @@ class AbstractValue(AbstractConstraint):
     """An abstract class of constraints that can be applied to one or more
     geometries that has a value associated with it.
     """
+
     VALUE_STR_FORMAT = "{value}{unit}"
+
     @property
     @abstractmethod
     def value(self) -> float:
         """The value that the constraint enforces."""
+
     @property
     def unit(self) -> str | None:
         """The unit of the constraint's value.
@@ -33,10 +36,12 @@ class AbstractValue(AbstractConstraint):
         :setter: Sets the constraints unit.
         """
         return self._unit
+
     @unit.setter
     def unit(self, value: str | None) -> None:
         self._unit = value
-    # Shared Public Methods #
+
+    # Public Methods
     def get_value_string(self, include_unit: bool=True) -> str:
         """Returns a string of the value of the constraint.
 
@@ -48,7 +53,7 @@ class AbstractValue(AbstractConstraint):
         if include_unit:
             return self.VALUE_STR_FORMAT.format(value=self.value, unit=self.unit)
         return str(self.value)
-    # Shared Dunder Methods
+
     def __str__(self) -> str:
         super_str = super().__str__().removesuffix(">")
         return f"{super_str}[{self.value}{self.unit}]>"
@@ -104,7 +109,6 @@ class Angle(AbstractValue):
         else:
             self.value = value
 
-    # Properties
     @property
     def quadrant(self) -> int:
         """The quadrant that the angle constraint is applied to.
@@ -112,6 +116,7 @@ class Angle(AbstractValue):
         :raises ValueError: If the quadrant is not 1, 2, 3, or 4.
         """
         return self._quadrant
+
     @quadrant.setter
     def quadrant(self, value: int) -> None:
         if value not in self.quadrants:
@@ -125,11 +130,12 @@ class Angle(AbstractValue):
         :raises TypeError: When the value is not a number.
         """
         return self._value
+
     @value.setter
     def value(self, value: float) -> None:
         self._value = value
 
-    # Public Methods #
+    # Public Methods
     def get_value(self, in_radians: bool=False) -> float:
         """Returns the value of the angle constraint.
 
@@ -146,6 +152,7 @@ class AbstractDistance(AbstractValue):
     """An abstract class of constraints that can be applied to one or more
     geometries that has a distance associated with it.
     """
+
     @property
     def value(self) -> float:
         """The distance the constraint enforces. When distance direction can be well-defined, the
@@ -154,6 +161,7 @@ class AbstractDistance(AbstractValue):
         distance. Distance should be nonnegative when distance direction cannot be well-defined.
         """
         return self._value
+
     @value.setter
     def value(self, value: float) -> None:
         self._value = value
@@ -211,6 +219,7 @@ class Distance(Abstract2GeometryDistance):
     """A constraint that defines the direct distance between two elements in 2D
     or 3D.
     """
+
     type_name = SketchConstraint.DISTANCE
 
 # 2D Only Classes #

--- a/src/pancad/constraints/distance.py
+++ b/src/pancad/constraints/distance.py
@@ -1,8 +1,7 @@
-"""A module providing classes for horizontal, vertical, and direct distance
-constraints. Distance can be used to force geometry elements to be at set
-distances from specified portions of each other. The horizontal and vertical
-variants can only be applied to 2D geometry and allow the distance
-to be limited to the x or y direction respectively.
+"""A module providing classes for horizontal, vertical, and direct distance constraints. Distance
+can be used to force geometry elements to be at set distances from specified portions of each
+other. The horizontal and vertical variants can only be applied to 2D geometry and allow the
+distance to be limited to the x or y direction respectively.
 """
 from __future__ import annotations
 
@@ -17,8 +16,8 @@ if TYPE_CHECKING:
     from pancad.abstract import AbstractGeometry, AbstractGeometrySystem
 
 class AbstractValue(AbstractConstraint):
-    """An abstract class of constraints that can be applied to one or more
-    geometries that has a value associated with it.
+    """An abstract class of constraints that can be applied to one or more geometries that has a
+    value associated with it.
     """
 
     VALUE_STR_FORMAT = "{value}{unit}"
@@ -30,11 +29,7 @@ class AbstractValue(AbstractConstraint):
 
     @property
     def unit(self) -> str | None:
-        """The unit of the constraint's value.
-
-        :getter: Returns the constraint's unit.
-        :setter: Sets the constraints unit.
-        """
+        """The unit of the constraint's value."""
         return self._unit
 
     @unit.setter
@@ -45,10 +40,8 @@ class AbstractValue(AbstractConstraint):
     def get_value_string(self, include_unit: bool=True) -> str:
         """Returns a string of the value of the constraint.
 
-        :param include_unit: Whether to include the unit in the output. Defaults
-            to 'True'.
-        :returns: A string with the value of the constraint. Includes the unit
-            in the string if include_unit is 'True'.
+        :param include_unit: Whether to include the unit in the output. Defaults to 'True'.
+        :returns: A string with the constraint's value. Adds the unit if include_unit is 'True'.
         """
         if include_unit:
             return self.VALUE_STR_FORMAT.format(value=self.value, unit=self.unit)
@@ -59,33 +52,28 @@ class AbstractValue(AbstractConstraint):
         return f"{super_str}[{self.value}{self.unit}]>"
 
 class Angle(AbstractValue):
-    """A class representing angle value constraints between lines. Stores and
-    returns angles in degrees by default since nearly all CAD programs take user
-    angle inputs in degrees. Can constrain:
+    """A class representing angle value constraints between lines. Stores and returns angles in
+    degrees by default since nearly all CAD programs take user angle inputs in degrees. Can
+    constrain:
 
     - :class:`~pancad.geometry.CoordinateSystem`
     - :class:`~pancad.geometry.Line`
     - :class:`~pancad.geometry.LineSegment`
     - :class:`~pancad.geometry.Ellipse`
 
-    :param reference_pairs: The (AbstractGeometry, ConstraintReference) pairs of
-        the geometry to be constrained.
+    :param geometry: The pair of geometry elements to be constrained.
     :param value: Angle value in degrees or radians.
-    :param quadrant: Quadrant selection between 1 (+, +), 2 (-, +), 3 (-, -)
-        and 4 (+, -). Initial selection is only dependent on the first element.
-        Example: the first quadrant is the one immediately clockwise of the
-        direction vector of the firest element. The clockwise selection method is
-        to simulate how users pick quadrants visually.
+    :param quadrant: Quadrant selection between 1 (+, +), 2 (-, +), 3 (-, -) and 4 (+, -). Initial
+        selection is only dependent on the first element. Example: the first quadrant is the one
+        immediately clockwise of the direction vector of the firest element. The clockwise
+        selection method is to simulate how users pick quadrants visually.
     :param uid: Unique identifier of the constraint.
     :param is_radians: Whether provided value is in radians. Defaults to False.
-    :raises ValueError: When the subgeometries are not 2D or if not exactly 2
-        pairs are provided.
+    :param system: The geometry system the constraint will be in.
+    :raises ValueError: When the geometry elements are not 2D and when not provided 2 elements.
     """
 
     type_name = SketchConstraint.ANGLE
-
-    quadrants = [1, 2, 3, 4]
-    """The allowed quadrant choices for where to place the angle."""
 
     def __init__(self,
                  *geometry: AbstractGeometry,
@@ -113,22 +101,19 @@ class Angle(AbstractValue):
     def quadrant(self) -> int:
         """The quadrant that the angle constraint is applied to.
 
-        :raises ValueError: If the quadrant is not 1, 2, 3, or 4.
+        :raises ValueError: When the quadrant is not 1, 2, 3, or 4.
         """
         return self._quadrant
 
     @quadrant.setter
     def quadrant(self, value: int) -> None:
-        if value not in self.quadrants:
-            raise ValueError(f"Quadrant must be one of {self.quadrants}")
+        if value not in {1, 2, 3, 4}:
+            raise ValueError("Quadrant must be 1, 2, 3, or 4")
         self._quadrant = value
 
     @property
     def value(self) -> float:
-        """Value of the angle constraint in degrees.
-
-        :raises TypeError: When the value is not a number.
-        """
+        """Value of the angle constraint in degrees."""
         return self._value
 
     @value.setter
@@ -139,18 +124,16 @@ class Angle(AbstractValue):
     def get_value(self, in_radians: bool=False) -> float:
         """Returns the value of the angle constraint.
 
-        :param in_radians: Whether to return the value in radians or degrees.
-            Defaults to 'False'.
-        :returns: The angle value in degrees if in_radians is 'False', in
-            radians if 'True'.
+        :param in_radians: Whether to return the value in radians or degrees. Defaults to 'False'.
+        :returns: The angle value in degrees. Returns in radians when 'in_radians' is 'True'.
         """
         if in_radians:
             return math.radians(self.value)
         return self.value
 
 class AbstractDistance(AbstractValue):
-    """An abstract class of constraints that can be applied to one or more
-    geometries that has a distance associated with it.
+    """An abstract class of constraints that can be applied to one or more geometries that has a
+    distance associated with it.
     """
 
     @property
@@ -167,17 +150,15 @@ class AbstractDistance(AbstractValue):
         self._value = value
 
 class Abstract2GeometryDistance(AbstractDistance):
-    """An abstract class of constraints that can be applied **exactly two**
-    geometries that has a distance associated with it. Distances cannot be
-    negative.
+    """An abstract class of constraints that can be applied **exactly two** geometries that has a
+    distance associated with it. Distances cannot be negative.
 
-    :param reference_pairs: The (AbstractGeometry, ConstraintReference) pairs of
-        the geometry to be constrained.
+    :param geometry: The pair of geometry elements to be constrained.
     :param value: Distance value.
     :param uid: Unique identifier of the constraint. Defaults to None.
     :param unit: The unit of the distance value. Defaults to None.
-    :raises ValueError: When not provided 2 pairs or when the subgeometries are
-        not the same dimension.
+    :param system: The geometry system the constraint will be in.
+    :raises ValueError: When not provided 2 elements or the elements are not the same dimension.
     """
     def __init__(self, *geometry: AbstractGeometry,
                  value: float, uid: str | None=None, unit: str | None=None,
@@ -197,11 +178,11 @@ class Abstract1GeometryDistance(AbstractDistance):
     geometry that has a distance associated with it. Distances cannot be
     negative.
 
-    :param reference_pairs: The (AbstractGeometry, ConstraintReference) pairs of
-        the geometry to be constrained.
+    :param geometry: The geometry element to be constrained.
     :param value: Distance value.
     :param uid: Unique identifier of the constraint. Defaults to None.
     :param unit: The unit of the distance value. Defaults to None.
+    :param system: The geometry system the constraint will be in.
     """
     def __init__(self, geometry: AbstractGeometry,
                  value: float, uid: str | None=None, unit: str | None=None,

--- a/src/pancad/constraints/distance.py
+++ b/src/pancad/constraints/distance.py
@@ -15,7 +15,6 @@ from pancad.constants import SketchConstraint
 
 if TYPE_CHECKING:
     from pancad.abstract import AbstractGeometry, AbstractGeometrySystem
-    from pancad.constants import ConstraintReference
 
 class AbstractValue(AbstractConstraint):
     """An abstract class of constraints that can be applied to one or more
@@ -218,11 +217,13 @@ class Distance(Abstract2GeometryDistance):
 ################################################################################
 class AbstractDistance2D(Abstract2GeometryDistance):
     """An abstract class for 2D distance constraints."""
-    def __init__(self, *geometry: AbstractGeometry, **kwargs) -> None:
+    def __init__(self, *geometry: AbstractGeometry,
+                 value: float, uid: str | None=None, unit: str | None=None,
+                 system: AbstractGeometrySystem | None=None) -> None:
         if any(len(g) != 2 for g in geometry):
             non_two_dimensional = [g for g in geometry if len(g) != 2]
             raise ValueError(f"Non-2D geometry provided: {non_two_dimensional}")
-        super().__init__(*geometry, **kwargs)
+        super().__init__(*geometry, value=value, uid=uid, unit=unit, system=system)
 
 class HorizontalDistance(AbstractDistance2D):
     """A constraint that sets the horizontal distance between two elements."""

--- a/src/pancad/constraints/distance.py
+++ b/src/pancad/constraints/distance.py
@@ -13,6 +13,8 @@ from pancad.abstract import AbstractConstraint
 from pancad.constants import SketchConstraint
 
 if TYPE_CHECKING:
+    from uuid import UUID
+
     from pancad.abstract import AbstractGeometry, AbstractGeometrySystem
 
 class AbstractValue(AbstractConstraint):
@@ -79,7 +81,7 @@ class Angle(AbstractValue):
                  *geometry: AbstractGeometry,
                  value: float,
                  quadrant: int,
-                 uid: str | None=None,
+                 uid: UUID | str | None=None,
                  is_radians: bool=False,
                  system: AbstractGeometrySystem | None=None) -> None:
         if len(geometry) != 2:
@@ -134,7 +136,25 @@ class Angle(AbstractValue):
 class AbstractDistance(AbstractValue):
     """An abstract class of constraints that can be applied to one or more geometries that has a
     distance associated with it.
+
+    :param geometry: The geometry elements to be constrained.
+    :param value: Distance value.
+    :param uid: Unique identifier of the constraint. Defaults to None.
+    :param unit: The unit of the distance value. Defaults to None.
+    :param system: The geometry system the constraint will be in.
+    :raises ValueError: When the geometry elements' dimensions do not match.
     """
+
+    def __init__(self, *geometry: AbstractGeometry,
+                 value: float, uid: UUID | str | None=None, unit: str | None=None,
+                 system: AbstractGeometrySystem | None=None) -> None:
+        self.uid = uid
+        super().__init__(system)
+        if len(set(len(g) for g in geometry)) != 1:
+            raise ValueError(f"Geometry not all the same dimension: {geometry}")
+        self._geometry = geometry
+        self.unit = unit
+        self.value = value
 
     @property
     def value(self) -> float:
@@ -161,17 +181,11 @@ class Abstract2GeometryDistance(AbstractDistance):
     :raises ValueError: When not provided 2 elements or the elements are not the same dimension.
     """
     def __init__(self, *geometry: AbstractGeometry,
-                 value: float, uid: str | None=None, unit: str | None=None,
+                 value: float, uid: UUID | str | None=None, unit: str | None=None,
                  system: AbstractGeometrySystem | None=None) -> None:
-        self.uid = uid
-        super().__init__(system)
         if len(geometry) != 2:
             raise ValueError(f"Expected 2 geometries, provided {geometry}")
-        if len(set(len(g) for g in geometry)) != 1:
-            raise ValueError(f"Geometry not all the same dimension: {geometry}")
-        self._geometry = geometry
-        self.unit = unit
-        self.value = value
+        super().__init__(*geometry, value=value, uid=uid, unit=unit, system=system)
 
 class Abstract1GeometryDistance(AbstractDistance):
     """An abstract class of constraints that can be applied **exactly one**
@@ -184,14 +198,12 @@ class Abstract1GeometryDistance(AbstractDistance):
     :param unit: The unit of the distance value. Defaults to None.
     :param system: The geometry system the constraint will be in.
     """
-    def __init__(self, geometry: AbstractGeometry,
-                 value: float, uid: str | None=None, unit: str | None=None,
+    def __init__(self, *geometry: AbstractGeometry,
+                 value: float, uid: UUID | str | None=None, unit: str | None=None,
                  system: AbstractGeometrySystem | None=None) -> None:
-        self.uid = uid
-        super().__init__(system)
-        self._geometry = [geometry]
-        self.unit = unit
-        self.value = value
+        if len(geometry) != 1:
+            raise ValueError(f"Expected 2 geometries, provided {geometry}")
+        super().__init__(*geometry, value=value, uid=uid, unit=unit, system=system)
 
 # 2D and 3D Distance Classes #
 ################################################################################
@@ -208,7 +220,7 @@ class Distance(Abstract2GeometryDistance):
 class AbstractDistance2D(Abstract2GeometryDistance):
     """An abstract class for 2D distance constraints."""
     def __init__(self, *geometry: AbstractGeometry,
-                 value: float, uid: str | None=None, unit: str | None=None,
+                 value: float, uid: UUID | str | None=None, unit: str | None=None,
                  system: AbstractGeometrySystem | None=None) -> None:
         if any(len(g) != 2 for g in geometry):
             non_two_dimensional = [g for g in geometry if len(g) != 2]

--- a/src/pancad/constraints/snapto.py
+++ b/src/pancad/constraints/snapto.py
@@ -11,6 +11,8 @@ from pancad.abstract import AbstractConstraint
 from pancad.constants import SketchConstraint
 
 if TYPE_CHECKING:
+    from uuid import UUID
+
     from pancad.abstract import AbstractGeometry, AbstractGeometrySystem
     from pancad.constants import ConstraintReference
 
@@ -19,7 +21,7 @@ class AbstractSingleSnapTo(AbstractConstraint):
     any further definition.
     """
     def __init__(self, *geometry: AbstractGeometry,
-                 uid: str | None=None, system: AbstractGeometrySystem | None=None) -> None:
+                 uid: UUID | str | None=None, system: AbstractGeometrySystem | None=None) -> None:
         self.uid = uid
         super().__init__(system)
         if len(geometry) != 1:
@@ -50,7 +52,7 @@ class AbstractSnapTo(AbstractConstraint):
     :param uid: The unique id of the constraint.
     """
     def __init__(self, *geometry: AbstractGeometry,
-                 uid: str | None=None, system: AbstractGeometrySystem | None=None) -> None:
+                 uid: UUID| str | None=None, system: AbstractGeometrySystem | None=None) -> None:
         self.uid = uid
         super().__init__(system)
         if len(geometry) not in [1, 2]:

--- a/src/pancad/constraints/snapto.py
+++ b/src/pancad/constraints/snapto.py
@@ -3,7 +3,6 @@ geometry contexts. pancad defines a snapto constraint as one that can be applied
 to geometry with no additional arguments but still meaningfully constrain the
 geometry.
 """
-
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
@@ -20,7 +19,7 @@ class AbstractSingleSnapTo(AbstractConstraint):
     any further definition.
     """
     def __init__(self, *geometry: AbstractGeometry,
-                 uid: str=None, system: AbstractGeometrySystem=None) -> None:
+                 uid: str | None=None, system: AbstractGeometrySystem | None=None) -> None:
         self.uid = uid
         super().__init__(system)
         if len(geometry) != 1:
@@ -51,7 +50,7 @@ class AbstractSnapTo(AbstractConstraint):
     :param uid: The unique id of the constraint.
     """
     def __init__(self, *geometry: AbstractGeometry,
-                 uid: str=None, system: AbstractGeometrySystem=None) -> None:
+                 uid: str | None=None, system: AbstractGeometrySystem | None=None) -> None:
         self.uid = uid
         super().__init__(system)
         if len(geometry) not in [1, 2]:

--- a/src/pancad/constraints/state_constraint.py
+++ b/src/pancad/constraints/state_constraint.py
@@ -14,6 +14,8 @@ from pancad.abstract import AbstractConstraint
 from pancad.constants import SketchConstraint
 
 if TYPE_CHECKING:
+    from uuid import UUID
+
     from pancad.abstract import AbstractGeometry, AbstractGeometrySystem
 
 class AbstractStateConstraint(AbstractConstraint):
@@ -24,7 +26,7 @@ class AbstractStateConstraint(AbstractConstraint):
     :param uid: The unique id of the constraint.
     """
     def __init__(self, *geometry: AbstractGeometry,
-                 uid: str | None=None, system: AbstractGeometrySystem | None=None) -> None:
+                 uid: UUID | str | None=None, system: AbstractGeometrySystem | None=None) -> None:
         self.uid = uid
         super().__init__(system)
         if len(geometry) != 2:

--- a/src/pancad/constraints/state_constraint.py
+++ b/src/pancad/constraints/state_constraint.py
@@ -24,7 +24,7 @@ class AbstractStateConstraint(AbstractConstraint):
     :param uid: The unique id of the constraint.
     """
     def __init__(self, *geometry: AbstractGeometry,
-                 uid: str=None, system: AbstractGeometrySystem=None) -> None:
+                 uid: str | None=None, system: AbstractGeometrySystem | None=None) -> None:
         self.uid = uid
         super().__init__(system)
         if len(geometry) != 2:

--- a/tests/geometry/test_make_constraint.py
+++ b/tests/geometry/test_make_constraint.py
@@ -1,0 +1,109 @@
+"""Tests for the generalized make_constraint function used as a one stop shop to create pancad
+constraints.
+"""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from pancad.constants import SketchConstraint as SC
+from pancad.constraints.distance import Angle, AbstractDistance
+from pancad.constraints.state_constraint import AbstractStateConstraint
+from pancad.constraints._generator import make_constraint
+from pancad.geometry.point import Point
+from pancad.geometry.line import Line
+
+if TYPE_CHECKING:
+    from pytest import FixtureRequest
+
+    from pancad.constraints.snapto import AbstractSnapTo, AbstractSingleSnapTo
+
+    NonValueConstraint = AbstractStateConstraint | AbstractSnapTo | AbstractSingleSnapTo
+
+@pytest.fixture(name="point_duo", params=[[(0, 0), (1, 1)], [(0, 0, 0), (1, 1, 1)]])
+def fixture_point_duo(request: FixtureRequest) -> tuple[Point, Point]:
+    """Returns a pair of same dimension pancad Points."""
+    points: tuple[Point, ...] = tuple()
+    for vector in request.param:
+        points = points + (Point(vector),)
+    assert len(points) == 2
+    return points
+
+@pytest.fixture(name="line_2d_duo", params=[[(1, 0), (1, 1)]])
+def fixture_line_2d_duo(request: FixtureRequest) -> tuple[Line, Line]:
+    """Returns a pair of 2 dimensional pancad Lines."""
+    lines: tuple[Line, ...] = tuple()
+    for direction in request.param:
+        lines = lines + (Line(Point([0] * len(direction)), direction),)
+    assert len(lines) == 2
+    return lines
+
+class TestNominal:
+    """Tests for make_constraint's inputs as they are expected to be input. These tests are also
+    used to check that static type checking the make_constraint function works in all cases.
+    """
+
+    @pytest.mark.parametrize("type_", [SC.COINCIDENT, "coincident"])
+    def test_coincident(self, type_: SC | str, point_duo: tuple[Point, Point]) -> None:
+        """Tests that it's possible to generate a Coincident constraint between Points."""
+        constraints: list[NonValueConstraint] = [
+            make_constraint(type_, *point_duo),
+            make_constraint(type_, *point_duo, uid=None),
+            make_constraint(type_, *point_duo, system=None),
+            make_constraint(type_, *point_duo, uid=None, system=None),
+        ]
+        for constraint in constraints:
+            assert isinstance(constraint, AbstractStateConstraint)
+
+    @pytest.mark.parametrize("type_", [SC.ANGLE, "angle"])
+    def test_angle(self, type_: SC | str, line_2d_duo: tuple[Line, Line]) -> None:
+        """Tests that it's possible to generate a Angle constraint between 2D Lines."""
+        constraints: list[Angle] = [
+            make_constraint(type_, *line_2d_duo, value=45, quadrant=1),
+            make_constraint(type_, *line_2d_duo, value=45, quadrant=1, is_radians=False),
+            make_constraint(type_, *line_2d_duo, value=45, quadrant=1, uid=None),
+            make_constraint(type_, *line_2d_duo, value=45, quadrant=1, uid=None,
+                            is_radians=False),
+            make_constraint(type_, *line_2d_duo, value=45, quadrant=1, system=None),
+            make_constraint(type_, *line_2d_duo, value=45, quadrant=1, system=None,
+                            is_radians=False),
+            make_constraint(type_, *line_2d_duo, value=45, quadrant=1, uid=None, system=None),
+            make_constraint(type_, *line_2d_duo, value=45, quadrant=1, uid=None, system=None,
+                            is_radians=False),
+        ]
+        for constraint in constraints:
+            assert isinstance(constraint, Angle)
+
+    @pytest.mark.parametrize("type_", [SC.DISTANCE, "distance"])
+    def test_distance(self, type_: SC | str, point_duo: tuple[Point, Point]) -> None:
+        """Tests that it's possible to generate a Distance constraint between Points."""
+        constraints: list[AbstractDistance] = [
+            make_constraint(type_, *point_duo, value=0),
+            make_constraint(type_, *point_duo, value=0, unit=None),
+            make_constraint(type_, *point_duo, value=0, unit="in"),
+            make_constraint(type_, *point_duo, value=0, uid=None),
+            make_constraint(type_, *point_duo, value=0, unit="in", uid=None),
+        ]
+        for constraint in constraints:
+            assert isinstance(constraint, AbstractDistance)
+
+class TestValueErrors:
+    """Test cases where make_constraint will raise ValueErrors due to incorrect input combos."""
+
+    def test_distance(self, point_duo: tuple[Point, Point]) -> None:
+        """Test that not providing a value for a distance constraint raises an error."""
+        with pytest.raises(ValueError, match="'value' was not provided"):
+            make_constraint("distance", *point_duo)
+
+    @pytest.mark.parametrize(
+        "value, quadrant, err_names",
+        [(45, None, "quadrant"), (None, 45, "value"), (None, None, "value, quadrant")]
+    )
+    def test_angle(self, value: float | None, quadrant: int | None, err_names: str,
+                   line_2d_duo: tuple[Line, Line]) -> None:
+        """Test that not providing a value or a quadrant and angle constraint raises an error."""
+        with pytest.raises(ValueError, match=f"'{err_names}' was not provided"):
+            # Testing ValueError that may occur to people not using static type checking, so mypy
+            # is ignored here.
+            make_constraint("angle", *line_2d_duo, value=value, quadrant=quadrant) # type: ignore


### PR DESCRIPTION
# Summary

Type safed all constraint classes and the make_constraint function. Refactored make_constraint to automatically support new constraints as they are added rather than needing to update a manual list. Closes #315 

# Changes

1. Type safed snapto, state_constraint, and distance by replaced Real with float, adding UUID to uid inputs, and correcting implicit Nones.
2. Changed the type_name property on AbstractConstraint into a ClassVar[SketchConstraint] to ensure it is actually a SketchConstraint type
3. Changed _generator.py to dynamically create a list of all pancad constraints using a new _all_constraints function that collects all concrete AbstractConstraint classes in snapto, distance, and state_constraint.
4. Created full overload specifications for creating Angles, AbstractDistance, and non value constraints with make_constraint
5. Added tests for make_constraint to confirm the types are correctly specified
6. Added a check for missing values to make_constraint and tests to check the missing check.